### PR TITLE
[WIP] Add a template schema

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -1,0 +1,3 @@
+This folder contains a template that you can use to start creating your own schema.
+
+For more information, see the doc [here]( ???? )

--- a/template/activities/templateActivity/items/item-1_select
+++ b/template/activities/templateActivity/items/item-1_select
@@ -1,0 +1,31 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/master/contexts/generic",
+    "@id": "item_1",
+    "@type": "reproschema:Field",
+    "prefLabel": "item_1",
+    "schema:schemaVersion": "0.0.1",
+    "schema:version": "0.0.1",
+    "question": "This is the item 1: a select item",
+    "ui": {
+        "inputType": "select"
+    },
+    "responseOptions": {
+        "schema:minValue": 1,
+        "schema:maxValue": 3,
+        "choices": [
+            {
+                "name": "response choice 1",
+                "value": 1
+            },
+            {
+                "name": "response choice 2",
+                "value": 2
+            },
+            {
+                "name": "response choice 3",
+                "value": 3
+            }
+        ],
+        "valueType": "xsd:string"
+    },
+}

--- a/template/activities/templateActivity/templateActivity_context
+++ b/template/activities/templateActivity/templateActivity_context
@@ -1,0 +1,10 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "templateActivity": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/templateActivity/items/",
+        "item-1_select": {
+            "@id": "templateActivity:item-1_select",
+            "@type": "@id"
+        }
+    }
+}

--- a/template/activities/templateActivity/templateActivity_schema
+++ b/template/activities/templateActivity/templateActivity_schema
@@ -1,0 +1,23 @@
+{
+    "@context": [
+        "https://raw.githubusercontent.com/ReproNim/reproschema/master/contexts/generic",
+        "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/templateActivity/templateActivity_context"
+    ],
+    "@type": "reproschema:Activity",
+    "@id": "templateActivity_schema",
+    "skos:prefLabel": "templateActivity",
+    "schema:schemaVersion": "0.0.1",
+    "schema:version": "0.0.1",
+    "ui": {
+        "order": [
+            "item-1_select"
+        ],
+        "shuffle": false,
+        "addProperties": [
+            {
+                "variableName": "item-1_select",
+                "isAbout": "item-1_select"
+            }
+        ]
+    }
+}

--- a/template/protocols/templateProtocol/README.md
+++ b/template/protocols/templateProtocol/README.md
@@ -1,0 +1,1 @@
+# template protocol

--- a/template/protocols/templateProtocol/templateProtocol_context
+++ b/template/protocols/templateProtocol/templateProtocol_context
@@ -1,0 +1,9 @@
+{
+    "@context": {
+        "activity_path": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/",
+        "template_protocol_schema": {
+            "@id": "activity_path:templateProtocol/templateProtocol_schema",
+            "@type": "@id"
+        }
+    }
+}

--- a/template/protocols/templateProtocol/templateProtocol_schema
+++ b/template/protocols/templateProtocol/templateProtocol_schema
@@ -1,0 +1,11 @@
+{
+    "@context": [
+        "https://raw.githubusercontent.com/ReproNim/reproschema/master/contexts/generic",
+        "https://raw.githubusercontent.com/ReproNim/reproschema/master/protocols/templateProtocol/templateProtocol_context"
+    ],
+    "@type": "reproschema:Protocol",
+    "@id": "templateProtocol_schema",
+    "skos:prefLabel": "Template Protocol Demo",
+    "schema:description": "This is the template protocol of reproschema.",
+    "landingPage": "https://raw.githubusercontent.com/ReproNim/reproschema/master/protocols/templateProtocol/README.md",
+}


### PR DESCRIPTION
## Schema template

Addressing one of the points in the issue #130 

### Points to clarify and to-dos.

- [ ] where to put the template
- [ ] actual content of the template
- [ ] doc on how to use the template

### Where to put the template

I am seeing several options for a template that could be used by new comers. I present 2 that are not mutually exclusive and actually suggest some synthesis of the 2.

#### Template as stand alone

Put the whole template schema in a separate `template` folder (like I did), but try to keep the URL pointing to the context and schema as if they were in their expected place.

So for example `templateProtocol_schema` and  `templateProtocol_context` are both in the folder `reproschema/template/protocols/templateProtocol/`

points to `reproschema/master/protocols/templateProtocol/templateProtocol_context`

```
"@context": [
        "https://raw.githubusercontent.com/ReproNim/reproschema/master/contexts/generic",
        "https://raw.githubusercontent.com/ReproNim/reproschema/master/protocols/templateProtocol/templateProtocol_context"
    ],
```
as if the templateProtocol was just with the other existing protocols.

##### Pros of the approach

- All the information about the template are in one location that is easy to find.
- Can make it easier to have for people to create a Protocol, Activity that they don't want to submit to this repo.

##### Cons of the approach

- The fact that the to be used this template to be used (i.e valid)  :
   - either has to be moved out of the template folder 
   - or the URLs to the contexts have to be changed

Either way this has to be made explicit in the instructions on how to use it.

- Left in that folder the template is subjected to the CI validation.


#### Template as just another protocol

In this case the template protocol folder and the template activity go with the other protocols and activity.

##### Pros of the approach

- It makes it valid protocol as the URL points to things that actually exist.
- The template is subjected to the CI validation.
- Can actually use the UI to show to users how the template renders, which I think is important for new users to see how the content of the JSON-LD is in the end related to what the UI gives them

##### Cons of the approach

- For a  new user this will require doing a bit of folder and find "archeology" to put the pieces together.


#### The best of both worlds

**I suggest that we keep we actually add the template protocol/activity in the protocol/activity folders for the reasons mentioned above but keep an updated copy in the template folder.**

I am usually not a fan of redundancy this could make things more convenient to new users and also make it easier to get a quick overview of how the different pieces of the schema relate to one another and how to navigate between them.

### Content of the template

My idea would be to: 

- start from the bare minimum to make it a valid schema (some sort of MWE)
- add some the things that we would suggest users add to the schema: the idea being that if those things are in the template schema it might nudge users into creating better schemas
- have a set of items that show all the type of items currently supported by the schema
- have 2 template activities to show how several assessments can be combined in one protocol

### Doc on how to use the template

My suggestion is to resuse some of the doc I am currently working on and to put it directly in the README of the template and adapt it a bit to tailor it even better to this template.