### PR TITLE
enh: expand example activity, protocol

### DIFF
--- a/examples/activities/activity1_embed.jsonld
+++ b/examples/activities/activity1_embed.jsonld
@@ -1,0 +1,76 @@
+{
+    "@context": "../../contexts/generic",
+    "@type": "reproschema:Activity",
+    "@id": "activity1.jsonld",
+    "skos:prefLabel": "Example 1",
+    "description": "Activity example 1",
+    "schemaVersion": "0.0.1",
+    "version": "0.0.1",
+    "citation": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1495268/",
+    "preamble": {
+        "en": "Over the last 2 weeks, how often have you been bothered by any of the following problems?",
+        "es": "Durante las últimas 2 semanas, ¿con qué frecuencia le han molestado los siguintes problemas?"
+    },
+    "ui": {
+        "addProperties": [
+            {   "isAbout": "items/item1.jsonld",
+                "variableName": "item1",
+                "requiredValue": true,
+                "isVis": true}
+        ],
+        "order": [
+            {
+                "@type": "reproschema:Field",
+                "@id": "items/item1.jsonld",
+                "skos:prefLabel": "item1",
+                "description": "Q1 of example 1",
+                "schemaVersion": "0.0.1",
+                "version": "0.0.1",
+                "question": {
+                    "en": "Little interest or pleasure in doing things",
+                    "es": "Poco interés o placer en hacer cosas"
+                },
+                "ui": {
+                    "inputType": "radio"
+                },
+                "responseOptions": {
+                    "valueType": "xsd:integer",
+                    "minValue": 0,
+                    "maxValue": 3,
+                    "multipleChoice": false,
+                    "choices": [
+                        {
+                            "name": {
+                                "en": "Not at all",
+                                "es": "Para nada"
+                            },
+                            "value": 0
+                        },
+                        {
+                            "name": {
+                                "en": "Several days",
+                                "es": "Varios días"
+                            },
+                            "value": 1
+                        },
+                        {
+                            "name": {
+                                "en": "More than half the days",
+                                "es": "Más de la mitad de los días"
+                            },
+                            "value": 2
+                        },
+                        {
+                            "name": {
+                                "en": "Nearly everyday",
+                                "es": "Casi todos los días"
+                            },
+                            "value": 3
+                        }
+                    ]
+                }
+            }
+        ],
+        "shuffle": false
+    }
+}

--- a/examples/activities/activity1_embed.jsonld
+++ b/examples/activities/activity1_embed.jsonld
@@ -2,7 +2,7 @@
     "@context": "../../contexts/generic",
     "@type": "reproschema:Activity",
     "@id": "activity1.jsonld",
-    "skos:prefLabel": "Example 1",
+    "prefLabel": "Example 1",
     "description": "Activity example 1",
     "schemaVersion": "0.0.1",
     "version": "0.0.1",
@@ -22,7 +22,7 @@
             {
                 "@type": "reproschema:Field",
                 "@id": "items/item1.jsonld",
-                "skos:prefLabel": "item1",
+                "prefLabel": "item1",
                 "description": "Q1 of example 1",
                 "schemaVersion": "0.0.1",
                 "version": "0.0.1",

--- a/examples/protocols/protocol1_embed.jsonld
+++ b/examples/protocols/protocol1_embed.jsonld
@@ -25,7 +25,7 @@
 			{
 				"@type": "reproschema:Activity",
 				"@id": "../activities/activity1.jsonld",
-				"skos:prefLabel": "Example 1",
+				"prefLabel": "Example 1",
 				"description": "Activity example 1",
 				"schemaVersion": "0.0.1",
 				"version": "0.0.1",
@@ -47,7 +47,7 @@
 						{
 							"@type": "reproschema:Field",
 							"@id": "../activities/items/item1.jsonld",
-							"skos:prefLabel": "item1",
+							"prefLabel": "item1",
 							"description": "Q1 of example 1",
 							"schemaVersion": "0.0.1",
 							"version": "0.0.1",

--- a/examples/protocols/protocol1_embed.jsonld
+++ b/examples/protocols/protocol1_embed.jsonld
@@ -1,0 +1,110 @@
+{
+	"@context": "../../contexts/generic",
+	"@type": "reproschema:Protocol",
+	"@id": "protocol1.jsonld",
+	"prefLabel": {
+		"en": "Protocol1",
+		"es": "Protocol1_es"
+	},
+	"description": "example Protocol",
+	"schemaVersion": "0.0.1",
+	"version": "0.0.1",
+	"ui": {
+		"addProperties": [
+			{
+				"isAbout": "../activities/activity1.jsonld",
+				"variableName": "activity1",
+				"prefLabel": {
+					"en": "Screening",
+					"es": "Screening_es"
+				},
+				"isVis": true
+			}
+		],
+		"order": [
+			{
+				"@type": "reproschema:Activity",
+				"@id": "../activities/activity1.jsonld",
+				"skos:prefLabel": "Example 1",
+				"description": "Activity example 1",
+				"schemaVersion": "0.0.1",
+				"version": "0.0.1",
+				"citation": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1495268/",
+				"preamble": {
+					"en": "Over the last 2 weeks, how often have you been bothered by any of the following problems?",
+					"es": "Durante las últimas 2 semanas, ¿con qué frecuencia le han molestado los siguintes problemas?"
+				},
+				"ui": {
+					"addProperties": [
+						{
+							"isAbout": "../activities/items/item1.jsonld",
+							"variableName": "item1",
+							"requiredValue": true,
+							"isVis": true
+						}
+					],
+					"order": [
+						{
+							"@type": "reproschema:Field",
+							"@id": "../activities/items/item1.jsonld",
+							"skos:prefLabel": "item1",
+							"description": "Q1 of example 1",
+							"schemaVersion": "0.0.1",
+							"version": "0.0.1",
+							"question": {
+								"en": "Little interest or pleasure in doing things",
+								"es": "Poco interés o placer en hacer cosas"
+							},
+							"ui": {
+								"inputType": "radio"
+							},
+							"responseOptions": {
+								"valueType": "xsd:integer",
+								"minValue": 0,
+								"maxValue": 3,
+								"multipleChoice": false,
+								"choices": [
+									{
+										"name": {
+											"en": "Not at all",
+											"es": "Para nada"
+										},
+										"value": 0
+									},
+									{
+										"name": {
+											"en": "Several days",
+											"es": "Varios días"
+										},
+										"value": 1
+									},
+									{
+										"name": {
+											"en": "More than half the days",
+											"es": "Más de la mitad de los días"
+										},
+										"value": 2
+									},
+									{
+										"name": {
+											"en": "Nearly everyday",
+											"es": "Casi todos los días"
+										},
+										"value": 3
+									}
+								]
+							}
+						}
+					],
+					"shuffle": false
+				}
+			}
+		],
+		"shuffle": false,
+		"allow": [
+			"reproschema:AutoAdvance",
+			"reproschema:DisableBack",
+			"reproschema:AllowExport"
+		]
+	}
+}


### PR DESCRIPTION
@sanuann - this is a draft at the moment just to show what an expanded protocol would look like. from a programmatic perspective this may be easier to use than download and expand.