### PR TITLE
added`"@type": "@id"` for `image` and removed `imageUrl`

### DIFF
--- a/contexts/generic
+++ b/contexts/generic
@@ -15,9 +15,6 @@
                 "@id": "reproschema:value"
             },
             "image": {
-                "@id": "schema:image"
-            },
-            "imageUrl": {
                 "@id": "schema:image",
                 "@type": "@id"
             },


### PR DESCRIPTION
had discussion with @satra and @djarecka on slack about `image` and `imageUrl`, we decide
- adding  `"@type": "@id"` here https://github.com/ReproNim/reproschema/blob/5453e3c5565b240aa2e28a5c14b50a6c223de64f/contexts/generic#L17-L20, otherwise `image` can't pass the validation
- removing `imageUrl` since `imageUrl` and `image` are the same now and only `image` was used in `demo-protocol` and `reproschema-library`

we can integrate these changes for the next release