### PR TITLE
changing LangString to Dict[str, str]

### DIFF
--- a/contexts/reproschema_new
+++ b/contexts/reproschema_new
@@ -19,7 +19,7 @@
          "@prefix": true
       },
       "xsd": "http://www.w3.org/2001/XMLSchema#",
-      "@vocab": "http://example.org/example/",
+      "@vocab": "http://schema.repronim.org/",
       "@version": 1.1,
       "@language": "en",
       "id": "@id",
@@ -28,17 +28,12 @@
       "about": {
          "@id": "schema:about"
       },
-      "additionalNotesObj": {
-         "@id": "reproschema:additionalNotesObj"
-      },
       "addProperties": {
-         "@id": "reproschema:addProperties",
          "@container": "@set",
          "@nest": "ui"
       },
       "allow": {
          "@type": "@id",
-         "@id": "reproschema:allow",
          "@container": "@set",
          "@nest": "ui"
       },
@@ -53,19 +48,14 @@
          "@type": "@id",
          "@id": "schema:audio"
       },
-      "choices": {
-         "@id": "reproschema:choices"
-      },
       "citation": {
          "@id": "schema:citation",
          "@container": "@language"
       },
       "column": {
-         "@id": "reproschema:column",
          "@type": "xsd:string"
       },
       "compute": {
-         "@id": "reproschema:compute",
          "@container": "@list"
       },
       "contentUrl": {
@@ -94,61 +84,44 @@
          "@id": "schema:image"
       },
       "imageUrl": {
-         "@type": "@id",
-         "@id": "reproschema:imageUrl"
+         "@type": "@id"
       },
       "inLanguage": {
          "@id": "schema:inLanguage",
          "@language": null
       },
       "inputType": {
-         "@id": "reproschema:inputType",
          "@type": "xsd:string",
          "@nest": "ui"
       },
       "isAbout": {
-         "@type": "@id",
-         "@id": "reproschema:isAbout"
+         "@type": "@id"
       },
       "isPartOf": {
          "@type": "@id",
          "@id": "schema:isPartOf"
       },
-      "isVis": {
-         "@id": "reproschema:isVis"
-      },
-      "jsExpression": {
-         "@id": "reproschema:jsExpression"
-      },
       "landingPage": {
          "@type": "@id",
-         "@id": "reproschema:landingPage",
          "@container": "@set"
       },
       "limit": {
-         "@id": "reproschema:limit",
          "@language": null
-      },
-      "maxRetakes": {
-         "@id": "reproschema:maxRetakes"
       },
       "maxValue": {
          "@id": "schema:maxValue"
       },
       "message": {
-         "@id": "reproschema:message",
          "@container": "@language"
       },
       "messages": {
-         "@container": "@set",
-         "@id": "reproschema:messages"
+         "@container": "@set"
       },
       "minValue": {
          "@id": "schema:minValue"
       },
       "multipleChoice": {
-         "@type": "xsd:boolean",
-         "@id": "reproschema:multipleChoice"
+         "@type": "xsd:boolean"
       },
       "name": {
          "@id": "schema:name",
@@ -156,12 +129,10 @@
       },
       "order": {
          "@type": "@id",
-         "@id": "reproschema:order",
          "@container": "@list",
          "@nest": "ui"
       },
       "overrideProperties": {
-         "@id": "reproschema:overrideProperties",
          "@container": "@set",
          "@nest": "ui"
       },
@@ -178,7 +149,6 @@
          "@container": "@language"
       },
       "randomMaxDelay": {
-         "@id": "reproschema:randomMaxDelay",
          "@language": null
       },
       "readonlyValue": {
@@ -186,11 +156,9 @@
          "@id": "schema:readonlyValue"
       },
       "responseOptions": {
-         "@type": "@id",
-         "@id": "reproschema:responseOptions"
+         "@type": "@id"
       },
       "schedule": {
-         "@id": "reproschema:schedule",
          "@language": null
       },
       "schemaVersion": {
@@ -199,26 +167,20 @@
       },
       "shuffle": {
          "@type": "xsd:boolean",
-         "@id": "reproschema:shuffle",
          "@nest": "ui"
       },
       "source": {
-         "@id": "reproschema:source",
          "@type": "xsd:string"
       },
       "startedAtTime": {
          "@type": "xsd:dateTime",
          "@id": "prov:startedAtTime"
       },
-      "statusOptions": {
-         "@id": "reproschema:statusOptions"
-      },
       "subject_id": {
          "@id": "nidm:subject_id"
       },
       "unitOptions": {
-         "@type": "@id",
-         "@id": "reproschema:unitOptions"
+         "@type": "@id"
       },
       "url": {
          "@type": "@id",
@@ -228,19 +190,12 @@
          "@type": "@id",
          "@id": "prov:used"
       },
-      "value": {
-         "@id": "reproschema:value"
-      },
       "valueRequired": {
          "@type": "xsd:boolean",
          "@id": "schema:valueRequired"
       },
       "valueType": {
-         "@type": "@id",
-         "@id": "reproschema:valueType"
-      },
-      "variableName": {
-         "@id": "reproschema:variableName"
+         "@type": "@id"
       },
       "version": {
          "@id": "schema:version",
@@ -261,47 +216,11 @@
       "Activity": {
          "@id": "reproschema:Activity"
       },
-      "AdditionalNoteObj": {
-         "@id": "reproschema:AdditionalNoteObj"
-      },
-      "AdditionalProperty": {
-         "@id": "reproschema:AdditionalProperty"
-      },
       "Agent": {
          "@id": "prov:Agent"
       },
-      "AllowExport": {
-         "@id": "reproschema:AllowExport"
-      },
-      "AllowReplay": {
-         "@id": "reproschema:AllowReplay"
-      },
-      "AllowSkip": {
-         "@id": "reproschema:AllowSkip"
-      },
-      "AutoAdvance": {
-         "@id": "reproschema:AutoAdvance"
-      },
-      "Choice": {
-         "@id": "reproschema:Choice"
-      },
-      "ComputeSpecification": {
-         "@id": "reproschema:ComputeSpecification"
-      },
       "CreativeWork": {
          "@id": "schema:CreativeWork"
-      },
-      "DisableBack": {
-         "@id": "reproschema:DisableBack"
-      },
-      "DontKnow": {
-         "@id": "reproschema:DontKnow"
-      },
-      "Item": {
-         "@id": "reproschema:Field"
-      },
-      "LandingPage": {
-         "@id": "reproschema:LandingPage"
       },
       "LangString": {
          "@id": "rdf:langString"
@@ -309,56 +228,11 @@
       "MediaObject": {
          "@id": "schema:MediaObject"
       },
-      "MessageSpecification": {
-         "@id": "reproschema:MessageSpecification"
-      },
-      "OverrideProperty": {
-         "@id": "reproschema:OverrideProperty"
-      },
-      "Participant": {
-         "@id": "reproschema:Participant"
-      },
-      "Protocol": {
-         "@id": "reproschema:Protocol"
-      },
-      "Response": {
-         "@id": "reproschema:Response"
-      },
-      "ResponseActivity": {
-         "@id": "reproschema:ResponseActivity"
-      },
-      "ResponseOption": {
-         "@id": "reproschema:ResponseOption"
-      },
-      "Schedule": {
-         "@id": "reproschema:Schedule"
-      },
-      "Skipped": {
-         "@id": "reproschema:Skipped"
-      },
-      "SoftwareAgent": {
-         "@id": "reproschema:SoftwareAgent"
-      },
       "StructuredValue": {
          "@id": "schema:StructuredValue"
       },
       "Thing": {
          "@id": "schema:Thing"
-      },
-      "TimedOut": {
-         "@id": "reproschema:TimedOut"
-      },
-      "UiActivity": {
-         "@id": "http://example.org/example/UiActivity"
-      },
-      "UiField": {
-         "@id": "http://example.org/example/UiField"
-      },
-      "UiProtocol": {
-         "@id": "http://example.org/example/UiProtocol"
-      },
-      "UnitOption": {
-         "@id": "reproschema:UnitOption"
       },
       "VideoObject": {
          "@id": "schema:VideoObject"

--- a/linkml-schema/reproschema.yaml
+++ b/linkml-schema/reproschema.yaml
@@ -1,5 +1,5 @@
 name: reproschema
-id: http://schema.repronim.org/ # todo: change this
+id: http://schema.repronim.org/
 imports:
 - linkml:types
 prefixes:
@@ -278,9 +278,6 @@ slots:
   readonlyValue:
     slot_uri: schema:readonlyValue
     range: boolean
-#  requiredValue:
-#    range: boolean
-#    slot_uri: schema:requiredValue
   responseOptions:
     title: Response options
     description: An element (object or by URL)to describe the properties of response of the Item.

--- a/linkml-schema/reproschema_linkml.py
+++ b/linkml-schema/reproschema_linkml.py
@@ -59,7 +59,7 @@ class AdditionalNoteObj(ConfiguredBaseModel):
     """
     column: Optional[str] = Field(None, title="column", description="""An element to define the column name where the note was taken from.""")
     source: Optional[str] = Field(None, title="source", description="""An element to define the source (eg. RedCap, NDA) where the note was taken from.""")
-    value: Optional[Union[Decimal, LangString, StructuredValue, bool, str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
+    value: Optional[Union[Decimal, Dict[str, str], StructuredValue, bool, str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
     
     
 
@@ -93,7 +93,7 @@ class Choice(ConfiguredBaseModel):
     """
     name: Optional[Dict[str, str]] = Field(default_factory=dict)
     image: Optional[ImageObject] = Field(None, title="image", description="""An image of the item. This can be a <a class=\"localLink\" href=\"http://schema.org/URL\">URL</a> or a fully described <a class=\"localLink\" href=\"http://schema.org/ImageObject\">ImageObject</a>.""")
-    value: Optional[Union[Decimal, LangString, StructuredValue, bool, str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
+    value: Optional[Union[Decimal, Dict[str, str], StructuredValue, bool, str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
     
     
 
@@ -168,16 +168,7 @@ class LandingPage(ConfiguredBaseModel):
     """
     inLanguage: Optional[str] = Field(None)
     id: Optional[str] = Field(None)
-    
-    
 
-class LangString(ConfiguredBaseModel):
-    """
-    RDF langString tuple
-    """
-    langstring_prefix: str = Field(..., description="""The language prefix component of a langString.""")
-    langstring_value: str = Field(..., description="""The value component of a langString.""")
-    
     
 
 class MediaObject(CreativeWork):
@@ -268,7 +259,7 @@ class Response(CreativeWork):
     Describes the response of an item.
     """
     isAbout: Optional[Union[Activity, Item, str]] = Field(None, title="isAbout", description="""A pointer to the node describing the item.""")
-    value: Optional[Union[Decimal, LangString, StructuredValue, bool, str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
+    value: Optional[Union[Decimal, Dict[str, str], StructuredValue, bool, str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
     wasAttributedTo: Optional[Participant] = Field(None)
     id: Optional[str] = Field(None)
     category: Optional[str] = Field(None)
@@ -345,7 +336,7 @@ class UnitOption(ConfiguredBaseModel):
     An object to represent a human displayable name alongside the more formal value for units.
     """
     prefLabel: Optional[Dict[str, str]] = Field(default_factory=dict, title="preferred label", description="""The preferred label.""")
-    value: Optional[Union[LangString, str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
+    value: Optional[Union[Dict[str, str], str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
     
     
 
@@ -370,7 +361,6 @@ CreativeWork.model_rebuild()
 Activity.model_rebuild()
 Item.model_rebuild()
 LandingPage.model_rebuild()
-LangString.model_rebuild()
 MediaObject.model_rebuild()
 AudioObject.model_rebuild()
 ImageObject.model_rebuild()


### PR DESCRIPTION
@satra - as I mentioned yesterday, I believe keeping `LandgString` in the pydantic version doesn't make sense, since IMO it doesn't do what you believe it does.
Consider this part of `item1.jsonld`:
```
        {
            "name": {
                "en": "Nearly everyday",
                "es": "Casi todos los días"
            },
            "value": {"@value": "choice-with-lang", "@language": "en"}
        }
```
it works only because `value` had `str` within the `Union[]`. If I change it to the shorter version you like ` "value":  {"en":  "choice-with-lang"}`, it would not work with the pydantic version. Unless we use `Dict[str, str]`


(I will look into the linkml prefix more, but I really didn't have time yesterday)

**EDIT**
I've also added some changes from my old branch that allow to have shorter context
