### PR TITLE
adding CreativeWork to most of the classes

### DIFF
--- a/linkml-schema/reproschema.yaml
+++ b/linkml-schema/reproschema.yaml
@@ -394,7 +394,7 @@ classes:
   Activity:
     title: Activity
     description: An assessment in a protocol.
-    is_a: Thing
+    is_a: CreativeWork
     slots:
     - about
     - altLabel
@@ -591,7 +591,7 @@ classes:
   ResponseOption:
     title: Response option
     description: An element (object or by URL)to describe the properties of response of the Item.
-    is_a: Thing
+    is_a: CreativeWork
     slots:
     - choices
     - datumType

--- a/linkml-schema/reproschema.yaml
+++ b/linkml-schema/reproschema.yaml
@@ -1,5 +1,6 @@
 name: reproschema
 id: http://schema.repronim.org/
+version: 1.0.0
 imports:
 - linkml:types
 prefixes:
@@ -61,6 +62,7 @@ slots:
     - range: AudioObject
     inlined: true
   category:
+    description: A specific type of class.
     slot_uri: rdf:type
     range: uriorcurie
   choices:
@@ -120,7 +122,8 @@ slots:
     slot_uri: prov:generated
     range: uri
   id:
-    slot_uri: schema:id
+    description: A unique identifier for an item.
+    slot_uri: schema:identifier
     range: uri
   image:
     title: image
@@ -405,6 +408,7 @@ classes:
     description:
       A set of objects to define notes in a Item. For example, most Redcap and NDA
       data dictionaries have notes for each item which needs to be captured in reproschema
+    is_a: CreativeWork
     slots:
     - column
     - source
@@ -413,6 +417,7 @@ classes:
   AdditionalProperty:
     title: Additional properties
     description: An object to describe the various properties added to assessments and Items.
+    is_a: CreativeWork
     slots:
     - allow
     - isAbout
@@ -434,6 +439,7 @@ classes:
   Choice:
     title: Response choice
     description: An object to describe a response option.
+    is_a: CreativeWork
     slots:
     - name
     - image
@@ -442,6 +448,7 @@ classes:
   ComputeSpecification:
     title: Compute Specification
     description: An object to define computations in an activity or protocol.
+    is_a: CreativeWork
     slots:
     - jsExpression
     - variableName
@@ -480,9 +487,9 @@ classes:
   LandingPage:
     title: Landing Page
     description: An object to define the landing page of a protocol.
+    is_a: CreativeWork
     slots:
     - inLanguage
-    - id
     class_uri: reproschema:LandingPage
   langString:
     description: RDF langString tuple
@@ -504,6 +511,7 @@ classes:
   MessageSpecification:
     title: Message Specification
     description: An object to define messages in an activity or protocol.
+    is_a: CreativeWork
     slots:
     - jsExpression
     - message
@@ -511,6 +519,7 @@ classes:
   OverrideProperty:
     title: Additional properties
     description: An object to override the various properties added to assessments and Items.
+    is_a: CreativeWork
     slots:
     - isAbout
     - isVis
@@ -527,6 +536,7 @@ classes:
     description: An Agent describing characteristics associated with a participant.
     is_a: Agent
     slots:
+      - id
       - subject_id
     class_uri: reproschema:Participant
   Protocol: # TODO multiple types
@@ -588,6 +598,7 @@ classes:
     description:
       Captures information about some action that took place. It also links to information
       (entities) that were used during the activity
+    is_a: CreativeWork
     slots:
     - version
     - url
@@ -595,8 +606,6 @@ classes:
   StructuredValue:
     is_a: CreativeWork
     class_uri: schema:StructuredValue
-  Thing: # todo should we switch
-    class_uri: schema:Thing
   UI:
     title: todo
     description:
@@ -613,6 +622,7 @@ classes:
   UnitOption:
     title: Unit options
     description: An object to represent a human displayable name alongside the more formal value for units.
+    is_a: CreativeWork
     slots:
     - prefLabel
     - value

--- a/linkml-schema/reproschema.yaml
+++ b/linkml-schema/reproschema.yaml
@@ -62,7 +62,10 @@ slots:
     - range: AudioObject
     inlined: true
   category:
-    description: A specific type of class.
+    description:
+      Name of the high level ontology class in which this entity is categorized.
+      Corresponds to the label for the biolink entity type class.
+      In an RDF database it should be a model class URI. This field is multi-valued.
     slot_uri: rdf:type
     range: uriorcurie
   choices:
@@ -99,6 +102,9 @@ slots:
   contentUrl:
     slot_uri: schema:contentUrl
     range: uriorcurie
+  creator:
+    slot_uri: schema:creator
+    range: Person
   cronTable:
     title: cronTable
     description: TODO not described in reproschema
@@ -122,9 +128,11 @@ slots:
     slot_uri: prov:generated
     range: uri
   id:
-    description: A unique identifier for an item.
+    description:
+      A unique identifier for an entity.
+      Must be either a CURIE shorthand for a URI or a complete URI.
     slot_uri: schema:identifier
-    range: uri
+    range: uriorcurie
   image:
     title: image
     description:
@@ -386,7 +394,7 @@ classes:
   Activity:
     title: Activity
     description: An assessment in a protocol.
-    is_a: CreativeWork
+    is_a: Thing
     slots:
     - about
     - altLabel
@@ -408,7 +416,7 @@ classes:
     description:
       A set of objects to define notes in a Item. For example, most Redcap and NDA
       data dictionaries have notes for each item which needs to be captured in reproschema
-    is_a: CreativeWork
+    is_a: Thing
     slots:
     - column
     - source
@@ -417,7 +425,7 @@ classes:
   AdditionalProperty:
     title: Additional properties
     description: An object to describe the various properties added to assessments and Items.
-    is_a: CreativeWork
+    is_a: Thing
     slots:
     - allow
     - isAbout
@@ -439,7 +447,7 @@ classes:
   Choice:
     title: Response choice
     description: An object to describe a response option.
-    is_a: CreativeWork
+    is_a: Thing
     slots:
     - name
     - image
@@ -454,14 +462,15 @@ classes:
     - variableName
     class_uri: reproschema:ComputeSpecification
   CreativeWork:
+    is_a: Thing
     slots:
-      - id
       - category
+      - contentUrl
     class_uri: schema:CreativeWork
   ImageObject:
     is_a: MediaObject
     class_uri: schema:ImageObject
-  Item: #TODO: multiple @type in reproschema
+  Item:
     title: Item in an activity
     description: An item in an assessment.
     is_a: CreativeWork
@@ -503,7 +512,6 @@ classes:
     is_a: CreativeWork
     class_uri: schema:MediaObject
     slots:
-      - contentUrl
       - inLanguage
     slot_usage:
       contentUrl:
@@ -519,7 +527,7 @@ classes:
   OverrideProperty:
     title: Additional properties
     description: An object to override the various properties added to assessments and Items.
-    is_a: CreativeWork
+    is_a: Thing
     slots:
     - isAbout
     - isVis
@@ -583,7 +591,7 @@ classes:
   ResponseOption:
     title: Response option
     description: An element (object or by URL)to describe the properties of response of the Item.
-    is_a: CreativeWork
+    is_a: Thing
     slots:
     - choices
     - datumType
@@ -598,14 +606,19 @@ classes:
     description:
       Captures information about some action that took place. It also links to information
       (entities) that were used during the activity
-    is_a: CreativeWork
+    is_a: Thing
     slots:
     - version
     - url
     class_uri: reproschema:SoftwareAgent
   StructuredValue:
-    is_a: CreativeWork
+    is_a: Thing
     class_uri: schema:StructuredValue
+  Thing:
+    slots:
+      - id
+      - name
+    class_uri: schema:Thing
   UI:
     title: todo
     description:
@@ -622,7 +635,7 @@ classes:
   UnitOption:
     title: Unit options
     description: An object to represent a human displayable name alongside the more formal value for units.
-    is_a: CreativeWork
+    is_a: Thing
     slots:
     - prefLabel
     - value

--- a/linkml-schema/reproschema.yaml
+++ b/linkml-schema/reproschema.yaml
@@ -640,35 +640,45 @@ classes:
 enums:
   AllowedType:
     permissible_values:
-      AllowAltResponse:
+      reproschema:AllowAltResponse:
+        title: AllowAltResponse
         description: Indicates (by boolean) if alternate responses are allowed or not.
         meaning: reproschema:AllowAltResponse
-      AllowExport:
+      reproschema:AllowExport:
+        title: AllowExport
         description: Indicates (by boolean) if data can be exported or not.
         meaning: reproschema:AllowExport
-      AllowReplay:
+      reproschema:AllowReplay:
+        title: AllowReplay
         description: Indicates (by boolean) if items can be replayed or not.
         meaning: reproschema:AllowReplay
-      AllowSkip:
+      reproschema:AllowSkip:
+        title: AllowSkip
         description: Indicates (by boolean) if items can be skipped or not.
         meaning: reproschema:AllowSkip
-      AutoAdvance:
+      reproschema:AutoAdvance:
+        title: AutoAdvance
         description: Indicates (by boolean) if assessments in a protocol can auto advance or not.
         meaning: reproschema:AutoAdvance
-      DisableBack:
+      reproschema:DisableBack:
+        title: DisableBack
         description: Indicates (by boolean) if we can go back to a completed assessment in a protocol.
         meaning: reproschema:DisableBack
   MissingType:
     permissible_values:
-      Skipped:
+      reproschema:Skipped:
+        title: Skipped
         description: An element to describe the choice when the item is skipped.
         meaning: reproschema:Skipped
-      DontKnow:
+      reproschema:DontKnow:
+        title: DontKnow
         description: An element to describe the choice when response is not known.
         meaning: reproschema:DontKnow
-      Unknown:
+      reproschema:Unknown:
+        title: Unknown
         description: An element to describe the choice when the reason for missing response is unknown.
         meaning: reproschema:Unknown
-      TimedOut:
+      reproschema:TimedOut:
+        title: TimedOut
         description: A boolean element to describe if the response did not occur within the prescribed time.
         meaning: reproschema:TimedOut

--- a/linkml-schema/reproschema_linkml.py
+++ b/linkml-schema/reproschema_linkml.py
@@ -76,12 +76,20 @@ class Agent(ConfiguredBaseModel):
     pass
 
 
-class CreativeWork(ConfiguredBaseModel):
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+class Participant(Agent):
+    """
+    An Agent describing characteristics associated with a participant.
+    """
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    subject_id: Optional[str] = Field(None)
 
 
-class Activity(CreativeWork):
+class Thing(ConfiguredBaseModel):
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
+
+
+class Activity(Thing):
     """
     An assessment in a protocol.
     """
@@ -99,22 +107,22 @@ class Activity(CreativeWork):
     schemaVersion: Optional[str] = Field(None)
     ui: Optional[UI] = Field(None, title="UI", description="""An element to control UI specifications. Originally @nest in jsonld, but using a class in the model.""")
     version: Optional[str] = Field(None)
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
-class AdditionalNoteObj(CreativeWork):
+class AdditionalNoteObj(Thing):
     """
     A set of objects to define notes in a Item. For example, most Redcap and NDA data dictionaries have notes for each item which needs to be captured in reproschema
     """
     column: Optional[str] = Field(None, title="column", description="""An element to define the column name where the note was taken from.""")
     source: Optional[str] = Field(None, title="source", description="""An element to define the source (eg. RedCap, NDA) where the note was taken from.""")
     value: Optional[Union[Decimal, Dict[str, str], MissingType, StructuredValue, bool, str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
-class AdditionalProperty(CreativeWork):
+class AdditionalProperty(Thing):
     """
     An object to describe the various properties added to assessments and Items.
     """
@@ -129,19 +137,25 @@ class AdditionalProperty(CreativeWork):
     valueRequired: Optional[bool] = Field(None)
     variableName: Optional[str] = Field(None, title="variableName", description="""The name used to represent an item.""")
     ui: Optional[UI] = Field(None, title="UI", description="""An element to control UI specifications. Originally @nest in jsonld, but using a class in the model.""")
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
-class Choice(CreativeWork):
+class Choice(Thing):
     """
     An object to describe a response option.
     """
     name: Optional[Dict[str, str]] = Field(default_factory=dict)
     image: Optional[Union[ImageObject, str]] = Field(None, title="image", description="""An image of the item. This can be a <a class=\"localLink\" href=\"http://schema.org/URL\">URL</a> or a fully described <a class=\"localLink\" href=\"http://schema.org/ImageObject\">ImageObject</a>.""")
     value: Optional[Union[Decimal, Dict[str, str], MissingType, StructuredValue, bool, str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+
+
+class CreativeWork(Thing):
+    category: Optional[str] = Field(None, description="""Name of the high level ontology class in which this entity is categorized. Corresponds to the label for the biolink entity type class. In an RDF database it should be a model class URI. This field is multi-valued.""")
+    contentUrl: Optional[str] = Field(None)
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
 class ComputeSpecification(CreativeWork):
@@ -150,8 +164,10 @@ class ComputeSpecification(CreativeWork):
     """
     jsExpression: Optional[str] = Field(None, title="JavaScript Expression", description="""A JavaScript expression for computations. A JavaScript expression to compute a score from other variables.""")
     variableName: Optional[str] = Field(None, title="variableName", description="""The name used to represent an item.""")
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    category: Optional[str] = Field(None, description="""Name of the high level ontology class in which this entity is categorized. Corresponds to the label for the biolink entity type class. In an RDF database it should be a model class URI. This field is multi-valued.""")
+    contentUrl: Optional[str] = Field(None)
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
 class Item(CreativeWork):
@@ -175,8 +191,10 @@ class Item(CreativeWork):
     ui: Optional[UI] = Field(None, title="UI", description="""An element to control UI specifications. Originally @nest in jsonld, but using a class in the model.""")
     version: Optional[str] = Field(None)
     video: Optional[VideoObject] = Field(None)
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    category: Optional[str] = Field(None, description="""Name of the high level ontology class in which this entity is categorized. Corresponds to the label for the biolink entity type class. In an RDF database it should be a model class URI. This field is multi-valued.""")
+    contentUrl: Optional[str] = Field(None)
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
 class LandingPage(CreativeWork):
@@ -184,32 +202,37 @@ class LandingPage(CreativeWork):
     An object to define the landing page of a protocol.
     """
     inLanguage: Optional[str] = Field(None)
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    category: Optional[str] = Field(None, description="""Name of the high level ontology class in which this entity is categorized. Corresponds to the label for the biolink entity type class. In an RDF database it should be a model class URI. This field is multi-valued.""")
+    contentUrl: Optional[str] = Field(None)
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
 class MediaObject(CreativeWork):
     """
     Add description
     """
-    contentUrl: str = Field(...)
     inLanguage: Optional[str] = Field(None)
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    category: Optional[str] = Field(None, description="""Name of the high level ontology class in which this entity is categorized. Corresponds to the label for the biolink entity type class. In an RDF database it should be a model class URI. This field is multi-valued.""")
+    contentUrl: str = Field(...)
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
 class AudioObject(MediaObject):
-    contentUrl: str = Field(...)
     inLanguage: Optional[str] = Field(None)
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    category: Optional[str] = Field(None, description="""Name of the high level ontology class in which this entity is categorized. Corresponds to the label for the biolink entity type class. In an RDF database it should be a model class URI. This field is multi-valued.""")
+    contentUrl: str = Field(...)
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
 class ImageObject(MediaObject):
-    contentUrl: str = Field(...)
     inLanguage: Optional[str] = Field(None)
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    category: Optional[str] = Field(None, description="""Name of the high level ontology class in which this entity is categorized. Corresponds to the label for the biolink entity type class. In an RDF database it should be a model class URI. This field is multi-valued.""")
+    contentUrl: str = Field(...)
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
 class MessageSpecification(CreativeWork):
@@ -218,11 +241,13 @@ class MessageSpecification(CreativeWork):
     """
     jsExpression: Optional[str] = Field(None, title="JavaScript Expression", description="""A JavaScript expression for computations. A JavaScript expression to compute a score from other variables.""")
     message: Optional[Dict[str, str]] = Field(default_factory=dict, title="Message", description="""The message to be conditionally displayed for an item.""")
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    category: Optional[str] = Field(None, description="""Name of the high level ontology class in which this entity is categorized. Corresponds to the label for the biolink entity type class. In an RDF database it should be a model class URI. This field is multi-valued.""")
+    contentUrl: Optional[str] = Field(None)
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
-class OverrideProperty(CreativeWork):
+class OverrideProperty(Thing):
     """
     An object to override the various properties added to assessments and Items.
     """
@@ -235,16 +260,8 @@ class OverrideProperty(CreativeWork):
     schedule: Optional[str] = Field(None, title="Schedule", description="""An element to set make activity available/repeat info using ISO 8601 repeating interval format.""")
     valueRequired: Optional[bool] = Field(None)
     variableName: Optional[str] = Field(None, title="variableName", description="""The name used to represent an item.""")
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
-
-
-class Participant(Agent):
-    """
-    An Agent describing characteristics associated with a participant.
-    """
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    subject_id: Optional[str] = Field(None)
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
 class Protocol(CreativeWork):
@@ -263,8 +280,10 @@ class Protocol(CreativeWork):
     schemaVersion: Optional[str] = Field(None)
     ui: Optional[UI] = Field(None, title="UI", description="""An element to control UI specifications. Originally @nest in jsonld, but using a class in the model.""")
     version: Optional[str] = Field(None)
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    category: Optional[str] = Field(None, description="""Name of the high level ontology class in which this entity is categorized. Corresponds to the label for the biolink entity type class. In an RDF database it should be a model class URI. This field is multi-valued.""")
+    contentUrl: Optional[str] = Field(None)
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
 class Response(CreativeWork):
@@ -274,8 +293,10 @@ class Response(CreativeWork):
     isAbout: Optional[Union[Activity, Item, str]] = Field(None, title="isAbout", description="""A pointer to the node describing the item.""")
     value: Optional[Union[Decimal, Dict[str, str], MissingType, StructuredValue, bool, str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
     wasAttributedTo: Optional[Participant] = Field(None)
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    category: Optional[str] = Field(None, description="""Name of the high level ontology class in which this entity is categorized. Corresponds to the label for the biolink entity type class. In an RDF database it should be a model class URI. This field is multi-valued.""")
+    contentUrl: Optional[str] = Field(None)
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
 class ResponseActivity(CreativeWork):
@@ -288,11 +309,13 @@ class ResponseActivity(CreativeWork):
     startedAtTime: Optional[datetime ] = Field(None)
     used: Optional[List[str]] = Field(default_factory=list)
     wasAssociatedWith: Optional[SoftwareAgent] = Field(None)
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    category: Optional[str] = Field(None, description="""Name of the high level ontology class in which this entity is categorized. Corresponds to the label for the biolink entity type class. In an RDF database it should be a model class URI. This field is multi-valued.""")
+    contentUrl: Optional[str] = Field(None)
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
-class ResponseOption(CreativeWork):
+class ResponseOption(Thing):
     """
     An element (object or by URL)to describe the properties of response of the Item.
     """
@@ -303,23 +326,23 @@ class ResponseOption(CreativeWork):
     multipleChoice: Optional[bool] = Field(None, title="Multiple choice response expectation", description="""Indicates (by bool) if response for the Item has one or more answer.""")
     unitOptions: Optional[List[UnitOption]] = Field(default_factory=list, title="unitOptions", description="""A list of objects to represent a human displayable name alongside the more formal value for units.""")
     valueType: Optional[List[str]] = Field(default_factory=list, title="The type of the response", description="""The type of the response of an item. For example, string, integer, etc.""")
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
-class SoftwareAgent(CreativeWork):
+class SoftwareAgent(Thing):
     """
     Captures information about some action that took place. It also links to information (entities) that were used during the activity
     """
     version: Optional[str] = Field(None)
     url: Optional[str] = Field(None)
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
-class StructuredValue(CreativeWork):
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+class StructuredValue(Thing):
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
 class UI(ConfiguredBaseModel):
@@ -335,31 +358,34 @@ class UI(ConfiguredBaseModel):
     readonlyValue: Optional[bool] = Field(None)
 
 
-class UnitOption(CreativeWork):
+class UnitOption(Thing):
     """
     An object to represent a human displayable name alongside the more formal value for units.
     """
     prefLabel: Optional[Dict[str, str]] = Field(default_factory=dict, title="preferred label", description="""The preferred label.""")
     value: Optional[Union[Dict[str, str], str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
 class VideoObject(MediaObject):
-    contentUrl: str = Field(...)
     inLanguage: Optional[str] = Field(None)
-    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
-    category: Optional[str] = Field(None, description="""A specific type of class.""")
+    category: Optional[str] = Field(None, description="""Name of the high level ontology class in which this entity is categorized. Corresponds to the label for the biolink entity type class. In an RDF database it should be a model class URI. This field is multi-valued.""")
+    contentUrl: str = Field(...)
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
 # Model rebuild
 # see https://pydantic-docs.helpmanual.io/usage/models/#rebuilding-a-model
 Agent.model_rebuild()
-CreativeWork.model_rebuild()
+Participant.model_rebuild()
+Thing.model_rebuild()
 Activity.model_rebuild()
 AdditionalNoteObj.model_rebuild()
 AdditionalProperty.model_rebuild()
 Choice.model_rebuild()
+CreativeWork.model_rebuild()
 ComputeSpecification.model_rebuild()
 Item.model_rebuild()
 LandingPage.model_rebuild()
@@ -368,7 +394,6 @@ AudioObject.model_rebuild()
 ImageObject.model_rebuild()
 MessageSpecification.model_rebuild()
 OverrideProperty.model_rebuild()
-Participant.model_rebuild()
 Protocol.model_rebuild()
 Response.model_rebuild()
 ResponseActivity.model_rebuild()

--- a/linkml-schema/reproschema_linkml.py
+++ b/linkml-schema/reproschema_linkml.py
@@ -47,7 +47,6 @@ class ConfiguredBaseModel(BaseModel):
 
 
 class AllowedType(str, Enum):
-
     # Indicates (by boolean) if alternate responses are allowed or not.
     AllowAltResponse = "reproschema:AllowAltResponse"
     # Indicates (by boolean) if data can be exported or not.
@@ -71,6 +70,7 @@ class MissingType(str, Enum):
     Unknown = "reproschema:Unknown"
     # A boolean element to describe if the response did not occur within the prescribed time.
     TimedOut = "reproschema:TimedOut"
+
 
 class Agent(ConfiguredBaseModel):
     pass
@@ -187,7 +187,6 @@ class LandingPage(CreativeWork):
     id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
     category: Optional[str] = Field(None, description="""A specific type of class.""")
 
-    
 
 class MediaObject(CreativeWork):
     """

--- a/linkml-schema/reproschema_linkml.py
+++ b/linkml-schema/reproschema_linkml.py
@@ -1,31 +1,49 @@
-from __future__ import annotations
-from datetime import datetime, date
-from enum import Enum
-
-from decimal import Decimal
-from typing import List, Dict, Optional, Any, Union
-from pydantic import BaseModel as BaseModel, ConfigDict,  Field, field_validator
+from __future__ import annotations 
+from datetime import (
+    datetime,
+    date
+)
+from decimal import Decimal 
+from enum import Enum 
 import re
 import sys
-if sys.version_info >= (3, 8):
-    from typing import Literal
+from typing import (
+    Any,
+    List,
+    Literal,
+    Dict,
+    Optional,
+    Union
+)
+from pydantic.version import VERSION  as PYDANTIC_VERSION 
+if int(PYDANTIC_VERSION[0])>=2:
+    from pydantic import (
+        BaseModel,
+        ConfigDict,
+        Field,
+        field_validator
+    )
 else:
-    from typing_extensions import Literal
-
+    from pydantic import (
+        BaseModel,
+        Field,
+        validator
+    )
 
 metamodel_version = "None"
-version = "None"
+version = "1.0.0"
+
 
 class ConfiguredBaseModel(BaseModel):
     model_config = ConfigDict(
-        validate_assignment=True,
-        validate_default=True,
-        extra = 'forbid',
-        arbitrary_types_allowed=True,
-        use_enum_values = True)
-
+        validate_assignment = True,
+        validate_default = True,
+        extra = "forbid",
+        arbitrary_types_allowed = True,
+        use_enum_values = True,
+        strict = False,
+    )
     pass
-
 
 
 class AllowedType(str, Enum):
@@ -54,67 +72,14 @@ class MissingType(str, Enum):
     # A boolean element to describe if the response did not occur within the prescribed time.
     TimedOut = "reproschema:TimedOut"
 
-
-
-class AdditionalNoteObj(ConfiguredBaseModel):
-    """
-    A set of objects to define notes in a Item. For example, most Redcap and NDA data dictionaries have notes for each item which needs to be captured in reproschema
-    """
-    column: Optional[str] = Field(None, title="column", description="""An element to define the column name where the note was taken from.""")
-    source: Optional[str] = Field(None, title="source", description="""An element to define the source (eg. RedCap, NDA) where the note was taken from.""")
-    value: Optional[Union[Decimal, Dict[str, str], MissingType, StructuredValue, bool, str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
-    
-    
-
-class AdditionalProperty(ConfiguredBaseModel):
-    """
-    An object to describe the various properties added to assessments and Items.
-    """
-    allow: Optional[List[AllowedType]] = Field(default_factory=list, title="allow", description="""An array of items indicating properties allowed on an activity or protocol.""")
-    isAbout: Optional[Union[Activity, Item, str]] = Field(None, title="isAbout", description="""A pointer to the node describing the item.""")
-    isVis: Optional[Union[bool, str]] = Field(None, title="visibility", description="""An element to describe (by boolean or conditional statement) visibility conditions of items in an assessment.""")
-    limit: Optional[str] = Field(None, title="limit", description="""An element to limit the duration (uses ISO 8601) this activity is allowed to be completed by once activity is available.""")
-    maxRetakes: Optional[Decimal] = Field(None, title="maxRetakes", description="""Defines number of times the item is allowed to be redone.""")
-    prefLabel: Optional[Dict[str, str]] = Field(default_factory=dict, title="preferred label", description="""The preferred label.""")
-    randomMaxDelay: Optional[str] = Field(None, title="randomMaxDelay", description="""Present activity/item within some random offset of activity available time up to the maximum specified by this ISO 8601 duration""")
-    schedule: Optional[str] = Field(None, title="Schedule", description="""An element to set make activity available/repeat info using ISO 8601 repeating interval format.""")
-    valueRequired: Optional[bool] = Field(None)
-    variableName: Optional[str] = Field(None, title="variableName", description="""The name used to represent an item.""")
-    ui: Optional[UI] = Field(None, title="UI", description="""An element to control UI specifications. Originally @nest in jsonld, but using a class in the model.""")
-    
-    
-
 class Agent(ConfiguredBaseModel):
-    
-    None
-    
-    
+    pass
 
-class Choice(ConfiguredBaseModel):
-    """
-    An object to describe a response option.
-    """
-    name: Optional[Dict[str, str]] = Field(default_factory=dict)
-    image: Optional[Union[ImageObject, str]] = Field(None, title="image", description="""An image of the item. This can be a <a class=\"localLink\" href=\"http://schema.org/URL\">URL</a> or a fully described <a class=\"localLink\" href=\"http://schema.org/ImageObject\">ImageObject</a>.""")
-    value: Optional[Union[Decimal, Dict[str, str], MissingType, StructuredValue, bool, str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
-    
-    
-
-class ComputeSpecification(ConfiguredBaseModel):
-    """
-    An object to define computations in an activity or protocol.
-    """
-    jsExpression: Optional[str] = Field(None, title="JavaScript Expression", description="""A JavaScript expression for computations. A JavaScript expression to compute a score from other variables.""")
-    variableName: Optional[str] = Field(None, title="variableName", description="""The name used to represent an item.""")
-    
-    
 
 class CreativeWork(ConfiguredBaseModel):
-    
-    id: Optional[str] = Field(None)
-    category: Optional[str] = Field(None)
-    
-    
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
+
 
 class Activity(CreativeWork):
     """
@@ -134,10 +99,60 @@ class Activity(CreativeWork):
     schemaVersion: Optional[str] = Field(None)
     ui: Optional[UI] = Field(None, title="UI", description="""An element to control UI specifications. Originally @nest in jsonld, but using a class in the model.""")
     version: Optional[str] = Field(None)
-    id: Optional[str] = Field(None)
-    category: Optional[str] = Field(None)
-    
-    
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
+
+
+class AdditionalNoteObj(CreativeWork):
+    """
+    A set of objects to define notes in a Item. For example, most Redcap and NDA data dictionaries have notes for each item which needs to be captured in reproschema
+    """
+    column: Optional[str] = Field(None, title="column", description="""An element to define the column name where the note was taken from.""")
+    source: Optional[str] = Field(None, title="source", description="""An element to define the source (eg. RedCap, NDA) where the note was taken from.""")
+    value: Optional[Union[Decimal, Dict[str, str], MissingType, StructuredValue, bool, str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
+
+
+class AdditionalProperty(CreativeWork):
+    """
+    An object to describe the various properties added to assessments and Items.
+    """
+    allow: Optional[List[AllowedType]] = Field(default_factory=list, title="allow", description="""An array of items indicating properties allowed on an activity or protocol.""")
+    isAbout: Optional[Union[Activity, Item, str]] = Field(None, title="isAbout", description="""A pointer to the node describing the item.""")
+    isVis: Optional[Union[bool, str]] = Field(None, title="visibility", description="""An element to describe (by boolean or conditional statement) visibility conditions of items in an assessment.""")
+    limit: Optional[str] = Field(None, title="limit", description="""An element to limit the duration (uses ISO 8601) this activity is allowed to be completed by once activity is available.""")
+    maxRetakes: Optional[Decimal] = Field(None, title="maxRetakes", description="""Defines number of times the item is allowed to be redone.""")
+    prefLabel: Optional[Dict[str, str]] = Field(default_factory=dict, title="preferred label", description="""The preferred label.""")
+    randomMaxDelay: Optional[str] = Field(None, title="randomMaxDelay", description="""Present activity/item within some random offset of activity available time up to the maximum specified by this ISO 8601 duration""")
+    schedule: Optional[str] = Field(None, title="Schedule", description="""An element to set make activity available/repeat info using ISO 8601 repeating interval format.""")
+    valueRequired: Optional[bool] = Field(None)
+    variableName: Optional[str] = Field(None, title="variableName", description="""The name used to represent an item.""")
+    ui: Optional[UI] = Field(None, title="UI", description="""An element to control UI specifications. Originally @nest in jsonld, but using a class in the model.""")
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
+
+
+class Choice(CreativeWork):
+    """
+    An object to describe a response option.
+    """
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
+    image: Optional[Union[ImageObject, str]] = Field(None, title="image", description="""An image of the item. This can be a <a class=\"localLink\" href=\"http://schema.org/URL\">URL</a> or a fully described <a class=\"localLink\" href=\"http://schema.org/ImageObject\">ImageObject</a>.""")
+    value: Optional[Union[Decimal, Dict[str, str], MissingType, StructuredValue, bool, str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
+
+
+class ComputeSpecification(CreativeWork):
+    """
+    An object to define computations in an activity or protocol.
+    """
+    jsExpression: Optional[str] = Field(None, title="JavaScript Expression", description="""A JavaScript expression for computations. A JavaScript expression to compute a score from other variables.""")
+    variableName: Optional[str] = Field(None, title="variableName", description="""The name used to represent an item.""")
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
+
 
 class Item(CreativeWork):
     """
@@ -160,17 +175,17 @@ class Item(CreativeWork):
     ui: Optional[UI] = Field(None, title="UI", description="""An element to control UI specifications. Originally @nest in jsonld, but using a class in the model.""")
     version: Optional[str] = Field(None)
     video: Optional[VideoObject] = Field(None)
-    id: Optional[str] = Field(None)
-    category: Optional[str] = Field(None)
-    
-    
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
 
-class LandingPage(ConfiguredBaseModel):
+
+class LandingPage(CreativeWork):
     """
     An object to define the landing page of a protocol.
     """
     inLanguage: Optional[str] = Field(None)
-    id: Optional[str] = Field(None)
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
 
     
 
@@ -180,39 +195,35 @@ class MediaObject(CreativeWork):
     """
     contentUrl: str = Field(...)
     inLanguage: Optional[str] = Field(None)
-    id: Optional[str] = Field(None)
-    category: Optional[str] = Field(None)
-    
-    
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
+
 
 class AudioObject(MediaObject):
-    
     contentUrl: str = Field(...)
     inLanguage: Optional[str] = Field(None)
-    id: Optional[str] = Field(None)
-    category: Optional[str] = Field(None)
-    
-    
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
+
 
 class ImageObject(MediaObject):
-    
     contentUrl: str = Field(...)
     inLanguage: Optional[str] = Field(None)
-    id: Optional[str] = Field(None)
-    category: Optional[str] = Field(None)
-    
-    
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
 
-class MessageSpecification(ConfiguredBaseModel):
+
+class MessageSpecification(CreativeWork):
     """
     An object to define messages in an activity or protocol.
     """
     jsExpression: Optional[str] = Field(None, title="JavaScript Expression", description="""A JavaScript expression for computations. A JavaScript expression to compute a score from other variables.""")
     message: Optional[Dict[str, str]] = Field(default_factory=dict, title="Message", description="""The message to be conditionally displayed for an item.""")
-    
-    
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
 
-class OverrideProperty(ConfiguredBaseModel):
+
+class OverrideProperty(CreativeWork):
     """
     An object to override the various properties added to assessments and Items.
     """
@@ -225,16 +236,17 @@ class OverrideProperty(ConfiguredBaseModel):
     schedule: Optional[str] = Field(None, title="Schedule", description="""An element to set make activity available/repeat info using ISO 8601 repeating interval format.""")
     valueRequired: Optional[bool] = Field(None)
     variableName: Optional[str] = Field(None, title="variableName", description="""The name used to represent an item.""")
-    
-    
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
+
 
 class Participant(Agent):
     """
     An Agent describing characteristics associated with a participant.
     """
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
     subject_id: Optional[str] = Field(None)
-    
-    
+
 
 class Protocol(CreativeWork):
     """
@@ -252,10 +264,9 @@ class Protocol(CreativeWork):
     schemaVersion: Optional[str] = Field(None)
     ui: Optional[UI] = Field(None, title="UI", description="""An element to control UI specifications. Originally @nest in jsonld, but using a class in the model.""")
     version: Optional[str] = Field(None)
-    id: Optional[str] = Field(None)
-    category: Optional[str] = Field(None)
-    
-    
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
+
 
 class Response(CreativeWork):
     """
@@ -264,10 +275,9 @@ class Response(CreativeWork):
     isAbout: Optional[Union[Activity, Item, str]] = Field(None, title="isAbout", description="""A pointer to the node describing the item.""")
     value: Optional[Union[Decimal, Dict[str, str], MissingType, StructuredValue, bool, str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
     wasAttributedTo: Optional[Participant] = Field(None)
-    id: Optional[str] = Field(None)
-    category: Optional[str] = Field(None)
-    
-    
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
+
 
 class ResponseActivity(CreativeWork):
     """
@@ -279,10 +289,9 @@ class ResponseActivity(CreativeWork):
     startedAtTime: Optional[datetime ] = Field(None)
     used: Optional[List[str]] = Field(default_factory=list)
     wasAssociatedWith: Optional[SoftwareAgent] = Field(None)
-    id: Optional[str] = Field(None)
-    category: Optional[str] = Field(None)
-    
-    
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
+
 
 class ResponseOption(CreativeWork):
     """
@@ -295,32 +304,24 @@ class ResponseOption(CreativeWork):
     multipleChoice: Optional[bool] = Field(None, title="Multiple choice response expectation", description="""Indicates (by bool) if response for the Item has one or more answer.""")
     unitOptions: Optional[List[UnitOption]] = Field(default_factory=list, title="unitOptions", description="""A list of objects to represent a human displayable name alongside the more formal value for units.""")
     valueType: Optional[List[str]] = Field(default_factory=list, title="The type of the response", description="""The type of the response of an item. For example, string, integer, etc.""")
-    id: Optional[str] = Field(None)
-    category: Optional[str] = Field(None)
-    
-    
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
 
-class SoftwareAgent(ConfiguredBaseModel):
+
+class SoftwareAgent(CreativeWork):
     """
     Captures information about some action that took place. It also links to information (entities) that were used during the activity
     """
     version: Optional[str] = Field(None)
     url: Optional[str] = Field(None)
-    
-    
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
+
 
 class StructuredValue(CreativeWork):
-    
-    id: Optional[str] = Field(None)
-    category: Optional[str] = Field(None)
-    
-    
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
 
-class Thing(ConfiguredBaseModel):
-    
-    None
-    
-    
 
 class UI(ConfiguredBaseModel):
     """
@@ -333,37 +334,34 @@ class UI(ConfiguredBaseModel):
     allow: Optional[List[AllowedType]] = Field(default_factory=list, title="allow", description="""An array of items indicating properties allowed on an activity or protocol.""")
     inputType: Optional[str] = Field(None, title="inputType", description="""An element to describe the input type of a Item.""")
     readonlyValue: Optional[bool] = Field(None)
-    
-    
 
-class UnitOption(ConfiguredBaseModel):
+
+class UnitOption(CreativeWork):
     """
     An object to represent a human displayable name alongside the more formal value for units.
     """
     prefLabel: Optional[Dict[str, str]] = Field(default_factory=dict, title="preferred label", description="""The preferred label.""")
     value: Optional[Union[Dict[str, str], str]] = Field(None, title="value", description="""The value for each option in choices or in additionalNotesObj""")
-    
-    
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
+
 
 class VideoObject(MediaObject):
-    
     contentUrl: str = Field(...)
     inLanguage: Optional[str] = Field(None)
-    id: Optional[str] = Field(None)
-    category: Optional[str] = Field(None)
-    
-    
+    id: Optional[str] = Field(None, description="""A unique identifier for an item.""")
+    category: Optional[str] = Field(None, description="""A specific type of class.""")
 
 
 # Model rebuild
 # see https://pydantic-docs.helpmanual.io/usage/models/#rebuilding-a-model
-AdditionalNoteObj.model_rebuild()
-AdditionalProperty.model_rebuild()
 Agent.model_rebuild()
-Choice.model_rebuild()
-ComputeSpecification.model_rebuild()
 CreativeWork.model_rebuild()
 Activity.model_rebuild()
+AdditionalNoteObj.model_rebuild()
+AdditionalProperty.model_rebuild()
+Choice.model_rebuild()
+ComputeSpecification.model_rebuild()
 Item.model_rebuild()
 LandingPage.model_rebuild()
 MediaObject.model_rebuild()
@@ -378,7 +376,6 @@ ResponseActivity.model_rebuild()
 ResponseOption.model_rebuild()
 SoftwareAgent.model_rebuild()
 StructuredValue.model_rebuild()
-Thing.model_rebuild()
 UI.model_rebuild()
 UnitOption.model_rebuild()
 VideoObject.model_rebuild()

--- a/linkml-schema/reproschema_linkml.py
+++ b/linkml-schema/reproschema_linkml.py
@@ -89,28 +89,6 @@ class Thing(ConfiguredBaseModel):
     name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
-class Activity(Thing):
-    """
-    An assessment in a protocol.
-    """
-    about: Optional[str] = Field(None, description="""The subject matter of the Field.""")
-    altLabel: Optional[Dict[str, str]] = Field(default_factory=dict, title="alternate label", description="""The alternate label.""")
-    associatedMedia: Optional[str] = Field(None, title="associatedMedia", description="""A media object that encodes this CreativeWork. This property is a synonym for encoding.""")
-    citation: Optional[Dict[str, str]] = Field(default_factory=dict)
-    compute: Optional[List[ComputeSpecification]] = Field(default_factory=list, title="computation", description="""An array of objects indicating computations in an activity or protocol and maps it to the corresponding Item. scoring logic is a subset of all computations that could be performed and not all computations will be scoring. For example, one may want to do conversion from one unit to another.""")
-    cronTable: Optional[str] = Field(None, title="cronTable", description="""TODO not described in reproschema""")
-    description: Optional[Dict[str, str]] = Field(default_factory=dict)
-    image: Optional[Union[ImageObject, str]] = Field(None, title="image", description="""An image of the item. This can be a <a class=\"localLink\" href=\"http://schema.org/URL\">URL</a> or a fully described <a class=\"localLink\" href=\"http://schema.org/ImageObject\">ImageObject</a>.""")
-    messages: Optional[List[MessageSpecification]] = Field(default_factory=list, title="messages", description="""An array of objects to define conditional messages in an activity or protocol.""")
-    preamble: Optional[Dict[str, str]] = Field(default_factory=dict, title="Preamble", description="""The preamble for an assessment""")
-    prefLabel: Optional[Dict[str, str]] = Field(default_factory=dict, title="preferred label", description="""The preferred label.""")
-    schemaVersion: Optional[str] = Field(None)
-    ui: Optional[UI] = Field(None, title="UI", description="""An element to control UI specifications. Originally @nest in jsonld, but using a class in the model.""")
-    version: Optional[str] = Field(None)
-    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
-    name: Optional[Dict[str, str]] = Field(default_factory=dict)
-
-
 class AdditionalNoteObj(Thing):
     """
     A set of objects to define notes in a Item. For example, most Redcap and NDA data dictionaries have notes for each item which needs to be captured in reproschema
@@ -152,6 +130,30 @@ class Choice(Thing):
 
 
 class CreativeWork(Thing):
+    category: Optional[str] = Field(None, description="""Name of the high level ontology class in which this entity is categorized. Corresponds to the label for the biolink entity type class. In an RDF database it should be a model class URI. This field is multi-valued.""")
+    contentUrl: Optional[str] = Field(None)
+    id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
+    name: Optional[Dict[str, str]] = Field(default_factory=dict)
+
+
+class Activity(CreativeWork):
+    """
+    An assessment in a protocol.
+    """
+    about: Optional[str] = Field(None, description="""The subject matter of the Field.""")
+    altLabel: Optional[Dict[str, str]] = Field(default_factory=dict, title="alternate label", description="""The alternate label.""")
+    associatedMedia: Optional[str] = Field(None, title="associatedMedia", description="""A media object that encodes this CreativeWork. This property is a synonym for encoding.""")
+    citation: Optional[Dict[str, str]] = Field(default_factory=dict)
+    compute: Optional[List[ComputeSpecification]] = Field(default_factory=list, title="computation", description="""An array of objects indicating computations in an activity or protocol and maps it to the corresponding Item. scoring logic is a subset of all computations that could be performed and not all computations will be scoring. For example, one may want to do conversion from one unit to another.""")
+    cronTable: Optional[str] = Field(None, title="cronTable", description="""TODO not described in reproschema""")
+    description: Optional[Dict[str, str]] = Field(default_factory=dict)
+    image: Optional[Union[ImageObject, str]] = Field(None, title="image", description="""An image of the item. This can be a <a class=\"localLink\" href=\"http://schema.org/URL\">URL</a> or a fully described <a class=\"localLink\" href=\"http://schema.org/ImageObject\">ImageObject</a>.""")
+    messages: Optional[List[MessageSpecification]] = Field(default_factory=list, title="messages", description="""An array of objects to define conditional messages in an activity or protocol.""")
+    preamble: Optional[Dict[str, str]] = Field(default_factory=dict, title="Preamble", description="""The preamble for an assessment""")
+    prefLabel: Optional[Dict[str, str]] = Field(default_factory=dict, title="preferred label", description="""The preferred label.""")
+    schemaVersion: Optional[str] = Field(None)
+    ui: Optional[UI] = Field(None, title="UI", description="""An element to control UI specifications. Originally @nest in jsonld, but using a class in the model.""")
+    version: Optional[str] = Field(None)
     category: Optional[str] = Field(None, description="""Name of the high level ontology class in which this entity is categorized. Corresponds to the label for the biolink entity type class. In an RDF database it should be a model class URI. This field is multi-valued.""")
     contentUrl: Optional[str] = Field(None)
     id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
@@ -315,7 +317,7 @@ class ResponseActivity(CreativeWork):
     name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
 
-class ResponseOption(Thing):
+class ResponseOption(CreativeWork):
     """
     An element (object or by URL)to describe the properties of response of the Item.
     """
@@ -326,6 +328,8 @@ class ResponseOption(Thing):
     multipleChoice: Optional[bool] = Field(None, title="Multiple choice response expectation", description="""Indicates (by bool) if response for the Item has one or more answer.""")
     unitOptions: Optional[List[UnitOption]] = Field(default_factory=list, title="unitOptions", description="""A list of objects to represent a human displayable name alongside the more formal value for units.""")
     valueType: Optional[List[str]] = Field(default_factory=list, title="The type of the response", description="""The type of the response of an item. For example, string, integer, etc.""")
+    category: Optional[str] = Field(None, description="""Name of the high level ontology class in which this entity is categorized. Corresponds to the label for the biolink entity type class. In an RDF database it should be a model class URI. This field is multi-valued.""")
+    contentUrl: Optional[str] = Field(None)
     id: Optional[str] = Field(None, description="""A unique identifier for an entity. Must be either a CURIE shorthand for a URI or a complete URI.""")
     name: Optional[Dict[str, str]] = Field(default_factory=dict)
 
@@ -381,11 +385,11 @@ class VideoObject(MediaObject):
 Agent.model_rebuild()
 Participant.model_rebuild()
 Thing.model_rebuild()
-Activity.model_rebuild()
 AdditionalNoteObj.model_rebuild()
 AdditionalProperty.model_rebuild()
 Choice.model_rebuild()
 CreativeWork.model_rebuild()
+Activity.model_rebuild()
 ComputeSpecification.model_rebuild()
 Item.model_rebuild()
 LandingPage.model_rebuild()


### PR DESCRIPTION
- adding CreativeWork to most of the classes
- adding description to CreativeWork slots
- slightly different formatting from  the linkml generator


@satra - could you please see the descriptions of `id` and `category`, I've realized that there is no `schema:id` just `schema:identifier`. Also not  completely sure about the category, since I haven't seen an example