### PR TITLE
[MAINT] add release workflow

### DIFF
--- a/.github/workflows/validate_and_release.yml
+++ b/.github/workflows/validate_and_release.yml
@@ -8,8 +8,13 @@ on:
       - main
   pull_request:
     branches: ['*']
-  release:
-    types: [published]
+  # Allow to trigger the generation of release files automatically
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'version number'
+        required: true
+        type: string
 
 jobs:
   validate:
@@ -33,7 +38,7 @@ jobs:
 
   release:
     needs: [validate]
-    if: github.event_name == 'release'
+    if: github.event == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -41,8 +46,20 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.12
+
     - name: Make a release
       run: |
-        echo "Making a release"
-        echo ${{ github.event_name }}
-    #     python scripts/makeRelease.py ci-release
+        echo "Making a release ${{ inputs.version }}"
+        mkdir releases/${{ inputs.version }}
+        cp contexts/reproschema releases/${{ inputs.version }}/base
+    #     python scripts/makeRelease.py ${{ inputs.version }}
+
+    -   name: Open pull requests to add files
+        uses: peter-evans/create-pull-request@v6
+        with:
+            commit-message: "[REL] adding files to for release ${{ inputs.version }}"
+            base: main
+            token: ${{ secrets.GITHUB_TOKEN }}
+            delete-branch: true
+            title: "[REL] adding files to for release ${{ inputs.version }}"
+            body: done via this [GitHub Action](https://github.com/${{ github.repository_owner }}/reproschema/blob/main/.github/workflows/validate_and_release.yml)

--- a/.github/workflows/validate_and_release.yml
+++ b/.github/workflows/validate_and_release.yml
@@ -15,10 +15,6 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-    - name: Dump GitHub context1
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
     - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -37,7 +33,8 @@ jobs:
 
   release:
     needs: [validate]
-    if: github.repository == 'ReproNim/reproschema'
+    # if: github.repository == 'ReproNim/reproschema'
+    if: ${{ github.event_name }} == 'release'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/validate_and_release.yml
+++ b/.github/workflows/validate_and_release.yml
@@ -34,7 +34,7 @@ jobs:
   release:
     needs: [validate]
     # if: github.repository == 'ReproNim/reproschema'
-    if: ${{ github.event_name }} == 'release'
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/validate_and_release.yml
+++ b/.github/workflows/validate_and_release.yml
@@ -45,4 +45,5 @@ jobs:
     - name: Make a release
       run: |
         echo "Making a release"
+        echo ${{ github.event_name }}
     #     python scripts/makeRelease.py ci-release

--- a/.github/workflows/validate_and_release.yml
+++ b/.github/workflows/validate_and_release.yml
@@ -15,6 +15,10 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
+    - name: Dump GitHub context1
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
     - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/validate_and_release.yml
+++ b/.github/workflows/validate_and_release.yml
@@ -1,19 +1,19 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
-name: Python package
+# - validate the protocol and activities in the repo with reproschema.py
+# - triggers a release when a github release is published
+name: validate and release
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
-    branches: '*'
+    branches: ['*']
+  release:
+    types: [published]
 
 jobs:
-  build:
-
+  validate:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -26,14 +26,22 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools
         pip install git+https://github.com/ReproNim/reproschema-py.git
-    - name: Test with pyshacl
+    - name: Validate content
       run: |
         python scripts/jsonParser.py
         reproschema validate examples
-    # TODO adapt make release
-    # TODO use mkdocs macro to update doc content
-    # - name: Make a release
-    #   run: |
+
+  release:
+    needs: [validate]
+    if: github.repository == 'ReproNim/reproschema'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+    - name: Make a release
+      run: |
+        echo "Making a release"
     #     python scripts/makeRelease.py ci-release
-    #     pip install pytablewriter
-    #     python scripts/editProperties.py ci-release

--- a/.github/workflows/validate_and_release.yml
+++ b/.github/workflows/validate_and_release.yml
@@ -33,7 +33,6 @@ jobs:
 
   release:
     needs: [validate]
-    # if: github.repository == 'ReproNim/reproschema'
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -35,18 +35,15 @@ The content of this repository is distributed under the [Apache 2.0 license](./L
 https://github.com/ReproNim/reproschema/graphs/contributors
 
 ### Developer notes
-To run the Python scripts in the scripts directory, you will need to install the
-following libraries via pip
+
+To run the Python scripts in the scripts directory,
+you will need to install the following libraries via pip
 
 - reproschema (makeRelease.py)
-- pytablewriter (editProperties.py)
 
-To make a new release:
+A new release can be triggered by making a Github release:
 
-```bash
-python scripts/makeRelease.py <version>
-python scripts/editProperties.py <version>
-```
+## Style guide
 
 In addition, this repo uses pre-commit to check styling.
 

--- a/README.md
+++ b/README.md
@@ -35,15 +35,18 @@ The content of this repository is distributed under the [Apache 2.0 license](./L
 https://github.com/ReproNim/reproschema/graphs/contributors
 
 ### Developer notes
-
-To run the Python scripts in the scripts directory,
-you will need to install the following libraries via pip
+To run the Python scripts in the scripts directory, you will need to install the
+following libraries via pip
 
 - reproschema (makeRelease.py)
+- pytablewriter (editProperties.py)
 
-A new release can be triggered by making a [Github release](https://github.com/ReproNim/reproschema/releases).
+To make a new release:
 
-## Style guide
+```bash
+python scripts/makeRelease.py <version>
+python scripts/editProperties.py <version>
+```
 
 In addition, this repo uses pre-commit to check styling.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ you will need to install the following libraries via pip
 
 - reproschema (makeRelease.py)
 
-A new release can be triggered by making a Github release:
+A new release can be triggered by making a [Github release](https://github.com/ReproNim/reproschema/releases).
 
 ## Style guide
 


### PR DESCRIPTION
reorganize the package release workflow into a validate and release workflow.

- rename it
- make it run on push to main, on all PRs, and manually when triggering the workflow from the action tab
- split into 2 jobs: the validate one runs all the time, the release needs validation to pass and only runs on manual triggers from the action tab