### PR TITLE
[WIP] adding GA to create a PR to reproschema-py

### DIFF
--- a/.github/workflows/push_reproschema_py.yml
+++ b/.github/workflows/push_reproschema_py.yml
@@ -1,7 +1,11 @@
 name: Create Pull Request in Another Repository
 on:
-  push:
-    paths: 'releases'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'version number'
+        required: true
+        type: string
 
 jobs:
   create-pull-request:
@@ -21,13 +25,9 @@ jobs:
       - name: Make changes to target repository
         id: changes
         run: |
-          LAST_VERSION=$(ls -lt releases/ | grep ^d | head -1 | awk '{print $9}')
-          echo "::set-output name=last_version::$LAST_VERSION"
-          echo "Last Version"
-          echo $LAST_VERSION
-          cp releases/$LAST_VERSION/reproschema.jsonld reproschema-py/reproschema.jsonld
+          cp releases/${{ inputs.version }}/reproschema.jsonld reproschema-py/reproschema.jsonld
           cd reproschema-py
-          git checkout -b new_release
+          git checkout -b release_${{ inputs.version }}
           # TODO: change to pydantic model
           # TODO: a script to change CONTEXTFILE_URL can be added
           git add reproschema.jsonld
@@ -39,12 +39,12 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
           cd reproschema-py
-          git push origin new_release
+          git push origin release_${{ inputs.version }}
       - name: Create pull request
         env:
           TARGET_REPO: repronim/reproschema-py
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
           curl -X POST -H "Authorization: token ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
-          -d '{"title":"Automated PR: Add new version of the model: ${{ steps.changes.outputs.last_version }}", "head":"new_release", "base":"main"}' \
+          -d '{"title":"Automated PR: Add new version of the model: ${{ inputs.version }}", "head":"release_${{ inputs.version }}", "base":"main"}' \
           https://api.github.com/repos/$TARGET_REPO/pulls

--- a/.github/workflows/push_reproschema_py.yml
+++ b/.github/workflows/push_reproschema_py.yml
@@ -1,0 +1,50 @@
+name: Create Pull Request in Another Repository
+on:
+  push:
+    paths: 'releases'
+
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+      - name: Set up Git and cloning repository
+        env:
+          TARGET_REPO: repronim/reproschema-py
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: |
+          git config --global user.name "djarecka"
+          git config --global user.email "djarecka@gmail.com"
+          git clone https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/$TARGET_REPO.git
+      - name: Make changes to target repository
+        id: changes
+        run: |
+          LAST_VERSION=$(ls -lt releases/ | grep ^d | head -1 | awk '{print $9}')
+          echo "::set-output name=last_version::$LAST_VERSION"
+          echo "Last Version"
+          echo $LAST_VERSION
+          cp releases/$LAST_VERSION/reproschema.jsonld reproschema-py/reproschema.jsonld
+          cd reproschema-py
+          git checkout -b new_release
+          # TODO: change to pydantic model
+          # TODO: a script to change CONTEXTFILE_URL can be added
+          git add reproschema.jsonld
+          git commit -m "Add new version of the model"
+          cd ..
+      - name: Push changes to target repository
+        env:
+          TARGET_REPO: repronim/reproschema-py
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: |
+          cd reproschema-py
+          git push origin new_release
+      - name: Create pull request
+        env:
+          TARGET_REPO: repronim/reproschema-py
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: |
+          curl -X POST -H "Authorization: token ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
+          -d '{"title":"Automated PR: Add new version of the model: ${{ steps.changes.outputs.last_version }}", "head":"new_release", "base":"main"}' \
+          https://api.github.com/repos/$TARGET_REPO/pulls


### PR DESCRIPTION
I've created a github workflow that pushes to reproschema-py

I was testing it for the current version so I was testing copying `reproschema.jsonld`, but it should be updated when we decide that pydantic is in releases directory

It can be also used to update `CONTEXTFILE_URL`

Unfortunately, I realized that my way of checking what is the latest release, by running `ls -lt releases/ | grep ^d | head -1 | awk '{print $9}'` works locally, but not in GA. If anyone knows how to change it that would be great.