### PR TITLE
Add ignore-regex for codespell to ignore possible "es" localizations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ line-length = 79
 [tool.codespell]
 skip = "env,venv,*.svg,pyproject.toml"
 ignore-words-list = "HSI"
+# Various localizations
+ignore-regex = "\"es\": \".*\""
 builtin = "clear,rare"
 
 [tool.isort]


### PR DESCRIPTION
Otherwise ATM would trigger one already

    ❯ codespell -C1
    :                                 "en": "Several days",
    >                                 "es": "Varios días"
    :                             },
    ./examples/activities/activity1_embed.jsonld:52: Varios ==> Various
    :                 "en": "Several days",
    >                 "es": "Varios días"
    :             },
    ./examples/activities/items/item1.jsonld:41: Varios ==> Various
    : 											"en": "Several days",
    > 											"es": "Varios días"
    : 										},
    ./examples/protocols/protocol1_embed.jsonld:77: Varios ==> Various