### PR TITLE
[wip] Adding InputType enum

### DIFF
--- a/linkml-schema/reproschema.yaml
+++ b/linkml-schema/reproschema.yaml
@@ -144,6 +144,7 @@ slots:
     title: inputType
     description: An element to describe the input type of a Item.
     slot_uri: reproschema:inputType
+    range: InputType
   isAbout:
     title: isAbout
     description: A pointer to the node describing the item.
@@ -687,3 +688,117 @@ enums:
         title: TimedOut
         description: A boolean element to describe if the response did not occur within the prescribed time.
         meaning: reproschema:TimedOut
+  InputType:
+    permissible_values:
+      radio:
+        title: radio
+        description: A radio button input type.
+        meaning: reproschema:radio
+      audioCheck:
+        title: audioCheck
+        description: An audio check input type.
+        meaning: reproschema:audioCheck
+      audioRecord:
+        title: audioRecord
+        description: An audio record input type.
+        meaning: reproschema:audioRecord
+      audioPassageRecord:
+        title: audioPassageRecord
+        description: An audio passage record input type.
+        meaning: reproschema:audioPassageRecord
+      audioImageRecord:
+        title: audioImageRecord
+        description: An audio image record input type.
+        meaning: reproschema:audioImageRecord
+      audioRecordNumberTask:
+        title: audioRecordNumberTask
+        description: An audio record number task input type.
+        meaning: reproschema:audioRecordNumberTask
+      audioRecordAudioTask:
+        title: audioRecordAudioTask
+        description: An audio record audio task input type.
+        meaning: reproschema:audioRecordAudioTask
+      audioRecordNoStop:
+        title: audioRecordNoStop
+        description: An audio record no stop input type.
+        meaning: reproschema:audioRecordNoStop
+      text:
+        title: text
+        description: A text input type.
+        meaning: reproschema:text
+      textarea:
+        title: textarea
+        description: A textarea input type.
+        meaning: reproschema:textarea
+      pid:
+        title: pid
+        description: A pid input type.
+        meaning: reproschema:pid
+      email:
+        title: email
+        description: An email input type.
+        meaning: reproschema:email
+      timeRange:
+        title: timeRange
+        description: A time range input type.
+        meaning: reproschema:timeRange
+      multitext:
+        title: multitext
+        description: A multitext input type.
+        meaning: reproschema:multitext
+      number:
+        title: number
+        description: A number input type.
+        meaning: reproschema:number
+      float:
+        title: float
+        description: A float input type.
+        meaning: reproschema:float
+      range:
+        title: range
+        description: A range input type.
+        meaning: reproschema:range
+      date:
+        title: date
+        description: A date input type.
+        meaning: reproschema:date
+      year:
+        title: year
+        description: A year input type.
+        meaning: reproschema:year
+      documentUpload:
+        title: documentUpload
+        description: A document upload input type.
+        meaning: reproschema:documentUpload
+      slider:
+        title: slider
+        description: A slider input type.
+        meaning: reproschema:slider
+      selectCountry:
+        title: selectCountry
+        description: A select country input type.
+        meaning: reproschema:selectCountry
+      selectState:
+        title: selectState
+        description: A select state input type.
+        meaning: reproschema:selectState
+      selectLanguage:
+        title: selectLanguage
+        description: A select language input type.
+        meaning: reproschema:selectLanguage
+      select:
+        title: select
+        description: A select input type.
+        meaning: reproschema:select
+      static:
+        title: static
+        description: A static input type.
+        meaning: reproschema:static
+      save:
+        title: save
+        description: A save input type.
+        meaning: reproschema:save
+      sign:
+        title: sign
+        description: A sign input type.
+        meaning: reproschema:sign


### PR DESCRIPTION
the input types added from [input selector](https://github.com/ReproNim/reproschema-ui/blob/771c460c50ca4edbef47ebdc959973102f2a9dcf/src/components/InputSelector/InputSelector.vue#L17)

@yibeichan - We should add some meaningful description, is it a place that it exists?