### PR TITLE
docs: update citations with JMIR 2025 publication

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@
 
 cff-version: 1.2.0
 
-title: reproschema
+title: ReproSchema
 
 abstract: >-
   A standardized form generation and data collection schema to harmonize results by design across projects.
@@ -14,11 +14,13 @@ license: CC-BY-4.0
 repository-code: https://github.com/ReproNim/reproschema.git
 
 message: >-
-  To cite the reproschema, please follow the instructions here:
-  https://zenodo.org/doi/10.5281/zenodo.4064939
+  If you use ReproSchema in your research, please cite our JMIR publication.
 
 identifiers:
-  - description: PDFs of the BIDS specification for versions 1.9.0 and above
+  - description: Journal article describing the ReproSchema ecosystem
+    type: doi
+    value: 10.2196/63343
+  - description: Zenodo archive of ReproSchema releases
     type: doi
     value: 10.5281/zenodo.4064939
 
@@ -28,6 +30,93 @@ keywords:
     - "jsonld"
     - "rdf"
     - "repronim"
+    - "reproducibility"
+    - "data collection"
 
 authors:
-  - family-names: Reproschema Contributors
+  - family-names: Chen
+    given-names: Yibei
+  - family-names: Jarecka
+    given-names: Dorota
+  - family-names: Abraham
+    given-names: Samuel
+  - family-names: Gau
+    given-names: Rémi
+  - family-names: Ng
+    given-names: Eric
+  - family-names: Low
+    given-names: Deshea
+  - family-names: Bevers
+    given-names: Isaac
+  - family-names: Johnson
+    given-names: Adam
+  - family-names: Keshavan
+    given-names: Anisha
+  - family-names: Klein
+    given-names: Arno
+  - family-names: Clucas
+    given-names: Jon
+  - family-names: Rosli
+    given-names: Zulfikar
+  - family-names: Hodge
+    given-names: Steven
+  - family-names: Linkersdörfer
+    given-names: Janosch
+  - family-names: Bartsch
+    given-names: Hauke
+  - family-names: Das
+    given-names: Samir
+  - family-names: Fair
+    given-names: Damien
+  - family-names: Kennedy
+    given-names: David
+  - family-names: Ghosh
+    given-names: Satrajit
+
+preferred-citation:
+  type: article
+  title: "Standardizing Survey Data Collection to Enhance Reproducibility: Development and Comparative Evaluation of the ReproSchema Ecosystem"
+  authors:
+    - family-names: Chen
+      given-names: Yibei
+    - family-names: Jarecka
+      given-names: Dorota
+    - family-names: Abraham
+      given-names: Samuel
+    - family-names: Gau
+      given-names: Rémi
+    - family-names: Ng
+      given-names: Eric
+    - family-names: Low
+      given-names: Deshea
+    - family-names: Bevers
+      given-names: Isaac
+    - family-names: Johnson
+      given-names: Adam
+    - family-names: Keshavan
+      given-names: Anisha
+    - family-names: Klein
+      given-names: Arno
+    - family-names: Clucas
+      given-names: Jon
+    - family-names: Rosli
+      given-names: Zulfikar
+    - family-names: Hodge
+      given-names: Steven
+    - family-names: Linkersdörfer
+      given-names: Janosch
+    - family-names: Bartsch
+      given-names: Hauke
+    - family-names: Das
+      given-names: Samir
+    - family-names: Fair
+      given-names: Damien
+    - family-names: Kennedy
+      given-names: David
+    - family-names: Ghosh
+      given-names: Satrajit
+  journal: "Journal of Medical Internet Research"
+  volume: 27
+  year: 2025
+  doi: 10.2196/63343
+  url: https://www.jmir.org/2025/1/e63343

--- a/README.md
+++ b/README.md
@@ -5,19 +5,277 @@
 
 # ReproSchema: Enhancing Research Reproducibility through Standardized Survey Data Collection
 
-The ReproSchema project integrates five key components designed to standardize research protocols and enhance consistency across various stages of data collection.
-- Foundational Schema ([reproschema](https://github.com/ReproNim/reproschema)): This core schema delineates the content and relationships of protocols, assessments, and items to ensure consistency and facilitate data harmonization across studies.
-- Assessment Library ([reproschema-library](https://github.com/ReproNim/reproschema-library)): This library provides a comprehensive collection of standardized questionnaires, supporting the application of uniform assessments across time and different studies.
-- Python-based CLI Tool ([reproschema-py](https://github.com/ReproNim/reproschema-py)): This command-line interface tool facilitates schema development and validation, aiding researchers in efficiently creating and refining data collection frameworks.
-- User Interface ([reproschema-ui](https://github.com/ReproNim/reproschema-ui)): This intuitive user interface simplifies the visualization and interaction with data, enhancing the manageability of the data collection process for researchers.
-- Protocol Template ([reproschema-protocol-cookiecutter](https://github.com/ReproNim/reproschema-protocol-cookiecutter)): This customizable template supports the design and implementation of research protocols tailored to specific study requirements.
+## Table of Contents
+
+- [Introduction](#introduction)
+- [Quick Start](#quick-start)
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Usage Examples](#usage-examples)
+  - [Creating a Simple Item](#creating-a-simple-item)
+  - [Creating an Activity](#creating-an-activity)
+  - [Creating a Protocol](#creating-a-protocol)
+  - [Validating Schemas](#validating-schemas)
+- [Schema Structure](#schema-structure)
+  - [File Formats](#file-formats)
+  - [Schema Components](#schema-components)
+- [ReproSchema Ecosystem](#reproschema-ecosystem)
+- [Repository Structure](#repository-structure)
+- [Development](#development)
+  - [Updating the Schema](#updating-the-schema)
+  - [Style Guidelines](#style-guidelines)
+  - [Release Process](#release-process)
+- [Resources and Links](#resources-and-links)
+- [Licenses](#licenses)
+- [Contributors](#contributors)
+
+## Introduction
+
+ReproSchema is a standardized framework for creating, sharing, and reusing cognitive and clinical assessments. It addresses the lack of consistency in assessment data acquisition across studies by providing a common schema that captures relationships between questionnaire elements from the start.
+
+**Key Benefits:**
+- 📊 **Rich Context**: JSON-LD format provides semantic relationships rather than flat CSV files
+- 🔄 **Version Control**: Track different versions of questionnaires (e.g., PHQ-9, PHQ-8)
+- 🌍 **Internationalization**: Built-in support for multiple languages
+- 🔗 **Persistent Identifiers**: Unique IDs for items, activities, and protocols
+- ✅ **Validation**: Schema validation using SHACL ensures data quality
+- 🚀 **Implementation Agnostic**: Use with any software platform
+
+## Quick Start
+
+Get started with ReproSchema in minutes:
+
+```bash
+# Install the ReproSchema Python package
+pip install reproschema
+
+# Validate an example schema
+reproschema validate examples/protocols/protocol1.jsonld
+
+# Create a new protocol from template (requires cookiecutter)
+pip install cookiecutter
+cookiecutter https://github.com/ReproNim/reproschema-protocol-cookiecutter
+```
+
+## Prerequisites
+
+Before using ReproSchema, ensure you have:
+
+- **Python 3.8+**: Required for the reproschema-py tools
+- **Git**: For version control and cloning repositories
+- **Text Editor**: Preferably with JSON/JSON-LD support (e.g., VS Code)
+- **Basic JSON Knowledge**: Understanding of JSON syntax
+
+Optional but recommended:
+- **GitHub Account**: For hosting and sharing your schemas
+- **Node.js**: If using the reproschema-ui interface
+
+## Installation
+
+### Installing the Python Package
+
+The easiest way to work with ReproSchema is through the Python package:
+
+```bash
+# Using pip
+pip install reproschema
+
+# Using pip with specific version
+pip install reproschema==1.0.0
+
+# For development (with latest changes)
+pip install git+https://github.com/ReproNim/reproschema-py.git
+```
+
+### Cloning the Repository
+
+To access examples and contribute to the schema:
+
+```bash
+git clone https://github.com/ReproNim/reproschema.git
+cd reproschema
+```
+
+## Usage Examples
+
+### Creating a Simple Item
+
+An item represents a single question in a questionnaire. Here's a basic example:
+
+```json
+{
+  "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0/contexts/reproschema",
+  "@type": "reproschema:Field",
+  "@id": "age_item",
+  "prefLabel": "Age",
+  "description": "Participant's age in years",
+  "schemaVersion": "1.0.0",
+  "version": "1.0.0",
+  "ui": {
+    "inputType": "number"
+  },
+  "responseOptions": {
+    "valueType": "xsd:integer",
+    "minValue": 0,
+    "maxValue": 120,
+    "unitCode": "years"
+  }
+}
+```
+
+### Creating an Activity
+
+An activity groups related items (like a complete questionnaire):
+
+```json
+{
+  "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0/contexts/reproschema",
+  "@type": "reproschema:Activity",
+  "@id": "demographics_activity",
+  "prefLabel": "Demographics",
+  "description": "Basic demographic information",
+  "schemaVersion": "1.0.0",
+  "version": "1.0.0",
+  "ui": {
+    "order": ["age_item", "gender_item"],
+    "shuffle": false,
+    "addProperties": [
+      {
+        "variableName": "age",
+        "isAbout": "age_item",
+        "isVis": true
+      },
+      {
+        "variableName": "gender",
+        "isAbout": "gender_item",
+        "isVis": true
+      }
+    ]
+  }
+}
+```
+
+### Creating a Protocol
+
+A protocol combines multiple activities for a complete study:
+
+```json
+{
+  "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0/contexts/reproschema",
+  "@type": "reproschema:Protocol",
+  "@id": "my_study_protocol",
+  "prefLabel": "My Research Study",
+  "description": "Protocol for my research study",
+  "schemaVersion": "1.0.0",
+  "version": "1.0.0",
+  "ui": {
+    "order": ["demographics_activity", "phq9_activity"],
+    "shuffle": false,
+    "addProperties": [
+      {
+        "variableName": "demographics",
+        "isAbout": "demographics_activity",
+        "prefLabel": "Demographics",
+        "isVis": true
+      },
+      {
+        "variableName": "phq9",
+        "isAbout": "phq9_activity",
+        "prefLabel": "PHQ-9 Depression Scale",
+        "isVis": true
+      }
+    ]
+  }
+}
+```
+
+### Validating Schemas
+
+Always validate your schemas to ensure they're correctly formatted:
+
+```bash
+# Validate a single file
+reproschema validate my_protocol.jsonld
+
+# Validate all files in a directory
+reproschema validate protocols/
+
+# Validate with detailed output
+reproschema --log-level DEBUG validate my_schema.jsonld
+```
+
+## Schema Structure
+
+### File Formats
+
+ReproSchema uses several file formats:
+
+- **JSON-LD (.jsonld)**: Primary format combining JSON with Linked Data
+- **Turtle (.ttl)**: RDF serialization format
+- **N-Triples (.nt)**: Line-based RDF format
+- **YAML**: Used for LinkML schema definitions
+
+### Schema Components
+
+The ReproSchema consists of three hierarchical levels:
+
+1. **Items (Fields)**: Individual questions or data points
+   - Question text and descriptions
+   - Input types (text, number, select, etc.)
+   - Response options and constraints
+   - Visibility conditions
+
+2. **Activities**: Collections of related items
+   - Groups items into logical assessments
+   - Defines item order and display logic
+   - Can include scoring computations
+   - Supports branching logic
+
+3. **Protocols**: Complete study designs
+   - Combines multiple activities
+   - Defines activity order and scheduling
+   - Manages participant flow
+   - Includes study-level metadata
+
+## ReproSchema Ecosystem
+
+The ReproSchema project integrates five key components designed to standardize research protocols and enhance consistency across various stages of data collection:
+
+### 1. Foundational Schema ([reproschema](https://github.com/ReproNim/reproschema))
+This core schema delineates the content and relationships of protocols, assessments, and items to ensure consistency and facilitate data harmonization across studies.
+
+### 2. Assessment Library ([reproschema-library](https://github.com/ReproNim/reproschema-library))
+A comprehensive collection of standardized questionnaires, supporting the application of uniform assessments across time and different studies.
+
+### 3. Python CLI Tool ([reproschema-py](https://github.com/ReproNim/reproschema-py))
+Command-line interface tool that facilitates schema development and validation, aiding researchers in efficiently creating and refining data collection frameworks.
+
+### 4. User Interface ([reproschema-ui](https://github.com/ReproNim/reproschema-ui))
+An intuitive web interface that simplifies the visualization and interaction with data, enhancing the manageability of the data collection process for researchers.
+
+### 5. Protocol Template ([reproschema-protocol-cookiecutter](https://github.com/ReproNim/reproschema-protocol-cookiecutter))
+A customizable template that supports the design and implementation of research protocols tailored to specific study requirements.
+
+## Repository Structure
 
 This repository contains:
 
-- the [different terms of the ReproSchema](./terms)
-- the [corresponding context files](./contexts)
-- a example of [a protocol based on the reproschema](./examples)
-- the [documentation](./docs)
+```
+reproschema/
+├── terms/              # ReproSchema vocabulary terms
+├── contexts/           # JSON-LD context files
+├── examples/           # Example protocols, activities, and items
+│   ├── activities/     # Sample activities
+│   ├── protocols/      # Sample protocols
+│   └── responses/      # Sample response data
+├── linkml-schema/      # LinkML schema definitions
+├── releases/           # Official release versions
+├── docs/               # Documentation
+│   ├── tutorials/      # Step-by-step guides
+│   ├── how-to/         # Task-specific instructions
+│   └── user-guide/     # Comprehensive user documentation
+└── scripts/            # Utility scripts
+```
 
 ## Developing ReproSchema
 
@@ -61,6 +319,12 @@ The content of this repository is distributed under the [Apache 2.0 license](./L
 ### Documentation
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />The corresponding documentation is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+
+## Citation
+
+If you use ReproSchema in your research, please cite our paper:
+
+Chen Y, Jarecka D, Abraham S, Gau R, Ng E, Low D, Bevers I, Johnson A, Keshavan A, Klein A, Clucas J, Rosli Z, Hodge S, Linkersdörfer J, Bartsch H, Das S, Fair D, Kennedy D, Ghosh S. **Standardizing Survey Data Collection to Enhance Reproducibility: Development and Comparative Evaluation of the ReproSchema Ecosystem**. J Med Internet Res 2025;27:e63343. DOI: [10.2196/63343](https://doi.org/10.2196/63343)
 
 ## Contributors
 

--- a/docs/how-to/visualize.md
+++ b/docs/how-to/visualize.md
@@ -13,14 +13,14 @@ to the [reproschema-ui app](https://www.repronim.org/reproschema-ui/)
 If you are hosting a schema on github, make sure that you are passing the URL of the **raw** content of the schema.
 For example, our demo protocol can be accessed at this URL:
 
-[https://github.com/ReproNim/reproschema-demo-protocol/blob/7ed1ae49279f75acdd57380fff1f8aaff2c7b511/reproschema_demo_protocol/reproschema_demo_protocol_schema](https://github.com/ReproNim/reproschema-demo-protocol/blob/7ed1ae49279f75acdd57380fff1f8aaff2c7b511/reproschema_demo_protocol/reproschema_demo_protocol_schema)
+[https://github.com/ReproNim/reproschema-demo-protocol/blob/main/reproschema_demo_protocol/reproschema_demo_protocol_schema](https://github.com/ReproNim/reproschema-demo-protocol/blob/main/reproschema_demo_protocol/reproschema_demo_protocol_schema)
 
 But to get access to the raw content of that file you must click on the `Raw` button
 once you have opened that page on github that will open this URL:
 
-[https://raw.githubusercontent.com/ReproNim/reproschema-demo-protocol/7ed1ae49279f75acdd57380fff1f8aaff2c7b511/reproschema_demo_protocol/reproschema_demo_protocol_schema](https://raw.githubusercontent.com/ReproNim/reproschema-demo-protocol/7ed1ae49279f75acdd57380fff1f8aaff2c7b511/reproschema_demo_protocol/reproschema_demo_protocol_schema).
+[https://raw.githubusercontent.com/ReproNim/reproschema-demo-protocol/main/reproschema_demo_protocol/reproschema_demo_protocol_schema](https://raw.githubusercontent.com/ReproNim/reproschema-demo-protocol/main/reproschema_demo_protocol/reproschema_demo_protocol_schema).
 
 So in the end the URL to preview this protocol as a web form would be:
 
-[https://www.repronim.org/reproschema-ui/#/?url=https://raw.githubusercontent.com/ReproNim/reproschema-demo-protocol/7ed1ae49279f75acdd57380fff1f8aaff2c7b511/reproschema_demo_protocol/reproschema_demo_protocol_schema](
-https://www.repronim.org/reproschema-ui/#/?url=https://raw.githubusercontent.com/ReproNim/reproschema-demo-protocol/7ed1ae49279f75acdd57380fff1f8aaff2c7b511/reproschema_demo_protocol/reproschema_demo_protocol_schema)
+[https://www.repronim.org/reproschema-ui/#/?url=https://raw.githubusercontent.com/ReproNim/reproschema-demo-protocol/main/reproschema_demo_protocol/reproschema_demo_protocol_schema](
+https://www.repronim.org/reproschema-ui/#/?url=https://raw.githubusercontent.com/ReproNim/reproschema-demo-protocol/main/reproschema_demo_protocol/reproschema_demo_protocol_schema)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,9 +25,13 @@ could save you from a lot of confusion. 😉
 
 ## How to cite
 
-If you need to cite ReproSchema, you can use this DOI:
+If you use ReproSchema in your research, please cite our paper:
 
--   [doi:10.5281/zenodo.4064940](https://doi.org/10.5281/zenodo.4064940).
+Chen Y, Jarecka D, Abraham S, Gau R, Ng E, Low D, Bevers I, Johnson A, Keshavan A, Klein A, Clucas J, Rosli Z, Hodge S, Linkersdörfer J, Bartsch H, Das S, Fair D, Kennedy D, Ghosh S. **Standardizing Survey Data Collection to Enhance Reproducibility: Development and Comparative Evaluation of the ReproSchema Ecosystem**. J Med Internet Res 2025;27:e63343. DOI: [10.2196/63343](https://doi.org/10.2196/63343)
+
+For the software itself, you can use this DOI:
+
+-   [doi:10.5281/zenodo.4064940](https://doi.org/10.5281/zenodo.4064940)
 
 ## Licence
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -28,7 +28,7 @@ through consistent terminologies and relationships that map to human cognition
 (e.g., [Cognitive Atlas](https://www.cognitiveatlas.org/),
 [Cognitive Paradigm Ontology](http://www.cogpo.org/)). Other efforts such as the
 National Institute for Mental Health (NIMH) Data Archive (NDA) and the National
-Library of Medicine (NLM) [Common Data Elements](https://www.nlm.nih.gov/cde/index.html)
+Library of Medicine (NLM) [Common Data Elements](https://cde.nlm.nih.gov/)
 have curated data elements corresponding to the items and calculated scores from
 these questionnaires. However, these resources are often used to make data
 consistent and reusable after, rather than during data collection. However,
@@ -55,7 +55,7 @@ stage by relying on a common `schema` that encodes how the different elements of
 the data and / or the metadata relate to one another. This way, all this relational
 information between these elements is captured from the very start as it is already
 embedded in the formal description of the assessment. This solution was inspired
-by the work of [CEDAR Metadata Model](https://more.metadatacenter.org/tools-training/outreach/cedar-template-model).
+by the work of [CEDAR Metadata Model](https://more.metadatacenter.org/).
 
 In this project we provide a comprehensive set of tools to create and use the
 schemas, while tracking the source of the schema, and changes to it over time.

--- a/docs/schema/schema.md
+++ b/docs/schema/schema.md
@@ -33,7 +33,7 @@ There are in fact more levels than this each and each level has its own schema:
 
 ## Detailed description
 
-The core model of ReproSchema was initially derived from the [CEDAR Metadata Model](https://more.metadatacenter.org/tools-training/outreach/cedar-template-model).
+The core model of ReproSchema was initially derived from the [CEDAR Metadata Model](https://more.metadatacenter.org/).
 To accommodate the needs of neuroimaging and other clinical and behavioral
 protocols and assessments the schema has evolved significantly. These changes
 include:


### PR DESCRIPTION
## Summary
Update all citation references to include the recently published JMIR paper describing the ReproSchema ecosystem.

## Changes
- Updated `CITATION.cff` with complete author list and JMIR publication details as preferred citation
- Added Citation section to `README.md` with formatted paper reference
- Updated `docs/index.md` to include both the paper citation and software DOI

## Related Publication
Chen Y, Jarecka D, Abraham S, et al. **Standardizing Survey Data Collection to Enhance Reproducibility: Development and Comparative Evaluation of the ReproSchema Ecosystem**. J Med Internet Res 2025;27:e63343. DOI: [10.2196/63343](https://doi.org/10.2196/63343)

## Testing
- [x] Verified CITATION.cff follows CFF v1.2.0 schema
- [x] Checked all author names match the publication
- [x] Confirmed DOI links are functional

This ensures users properly cite the academic publication when using ReproSchema in their research.